### PR TITLE
Fix unique default account rule

### DIFF
--- a/backend/__tests__/financial.tests.ts
+++ b/backend/__tests__/financial.tests.ts
@@ -115,6 +115,26 @@ describe('Módulo Financeiro', () => {
       expect(res.body).toHaveLength(2);
       expect(res.body.map((a: any) => a.name).sort()).toEqual(['Conta Corrente', 'Poupança'].sort());
     });
+
+    it('Impede ter mais de uma conta padrão', async () => {
+      await prisma.financialAccount.update({
+        where: { id: checkingAccountId },
+        data: { isDefault: true }
+      });
+
+      await expect(
+        prisma.financialAccount.update({
+          where: { id: savingsAccountId },
+          data: { isDefault: true }
+        })
+      ).rejects.toThrow();
+
+      const count = await prisma.financialAccount.count({
+        where: { companyId, isDefault: true }
+      });
+
+      expect(count).toBe(1);
+    });
   });
 
   describe('Categorias Financeiras', () => {

--- a/backend/prisma/migrations/20250620120000_default_account_unique/migration.sql
+++ b/backend/prisma/migrations/20250620120000_default_account_unique/migration.sql
@@ -1,0 +1,5 @@
+-- Drop old unique constraint on (companyId, isDefault)
+DROP INDEX IF EXISTS "FinancialAccount_companyId_isDefault_key";
+
+-- Enforce that only one default account exists per company
+CREATE UNIQUE INDEX "FinancialAccount_companyId_isDefault_true_key" ON "FinancialAccount"("companyId") WHERE "isDefault" = true;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -116,7 +116,6 @@ model FinancialAccount {
   userAccess            UserFinancialAccountAccess[]
 
   @@unique([name, companyId])
-  @@unique([companyId, isDefault], name: "unique_default_account_per_company") // ✅ CONSTRAINT
   @@index([companyId])
   @@index([companyId, isDefault]) // ✅ ÍNDICE OTIMIZADO
 }


### PR DESCRIPTION
## Summary
- remove Prisma-level unique constraint over `(companyId, isDefault)`
- add migration with partial unique index only when `isDefault` is `true`
- test that only one default account is allowed

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847421603c88330bbb2c62886a8a582