### PR TITLE
Padroniza cores e filtros nas páginas

### DIFF
--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -362,7 +362,7 @@ export default function UsersPage() {
 
         {/* ✅ FORMULÁRIO EXPANDIDO COM PERMISSÕES */}
         {showForm && (
-          <Card className="mb-6 border-2 border-accent">
+          <Card className="mb-6 border-2 border-[#2563eb]">
             <div className="space-y-6">
               <h3 className="text-lg font-medium text-white">
                 {editingUser ? `Editando: ${editingUser.name}` : 'Novo Usuário'}
@@ -406,7 +406,7 @@ export default function UsersPage() {
                   <select
                     value={formData.newRole}
                     onChange={(e) => setFormData({...formData, newRole: e.target.value})}
-                    className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-accent"
+                    className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-[#2563eb]"
                     disabled={formLoading}
                   >
                     <option value="USER">Usuário</option>
@@ -425,7 +425,7 @@ export default function UsersPage() {
                   <select
                     value={formData.companyId}
                     onChange={(e) => setFormData({...formData, companyId: e.target.value})}
-                    className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-accent"
+                    className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-[#2563eb]"
                     required={!editingUser}
                     disabled={formLoading}
                   >
@@ -533,8 +533,8 @@ export default function UsersPage() {
                     <tr 
                       key={user.id} 
                       className={`border-b border-gray-700 hover:bg-[#1a1f2b] ${
-                        editingUser?.id === user.id 
-                          ? 'bg-accent/10 border-accent/30' 
+                        editingUser?.id === user.id
+                          ? 'bg-[#2563eb]/10 border-[#2563eb]/30'
                           : ''
                       }`}
                     >
@@ -542,7 +542,7 @@ export default function UsersPage() {
                         <div className="flex items-center gap-1 justify-center">
                           <button
                             onClick={() => openEditForm(user)}
-                            className="p-1 text-gray-300 hover:text-accent transition-colors"
+                            className="p-1 text-gray-300 hover:text-[#2563eb] transition-colors"
                             title="Editar"
                             disabled={formLoading}
                           >

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -457,8 +457,8 @@ export default function AccountsPage() {
       )}
 
       {/* ✅ FORMULÁRIO COM CAMPO allowNegativeBalance */}
-      {showForm && (
-        <Card className="mb-6 border-2 border-accent">
+        {showForm && (
+          <Card className="mb-6 border-2 border-[#2563eb]">
           <div className="space-y-4">
             <h3 className="text-lg font-medium text-white">
               {editingAccount ? `Editando: ${editingAccount.name}` : 'Nova Conta Financeira'}
@@ -634,11 +634,11 @@ export default function AccountsPage() {
                 {filteredAccounts.map((account) => (
                   <tr 
                     key={account.id} 
-                    className={`border-b border-gray-700 hover:bg-[#1a1f2b] ${
-                      editingAccount?.id === account.id 
-                        ? 'bg-accent/10 border-accent/30' 
-                        : ''
-                    } ${!account.isActive ? 'opacity-60' : ''}`}
+                      className={`border-b border-gray-700 hover:bg-[#1a1f2b] ${
+                        editingAccount?.id === account.id
+                          ? 'bg-[#2563eb]/10 border-[#2563eb]/30'
+                          : ''
+                      } ${!account.isActive ? 'opacity-60' : ''}`}
                   >
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-1 justify-center">
@@ -668,7 +668,7 @@ export default function AccountsPage() {
                         </button>
                         <button
                           onClick={() => openEditForm(account)}
-                          className="p-1 text-gray-300 hover:text-accent transition-colors"
+                          className="p-1 text-gray-300 hover:text-[#2563eb] transition-colors"
                           title="Editar"
                           disabled={formLoading}
                         >

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -246,12 +246,13 @@ export default function CategoriesPage() {
 
       {/* Abas de Tipo */}
       {!showForm && (
-        <div className="flex space-x-1 mb-6">
+        <Card className="mb-6">
+          <div className="flex space-x-1">
           <button
             onClick={() => setActiveTab('EXPENSE')}
             className={`px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2 ${
-              activeTab === 'EXPENSE' 
-                ? 'bg-red-600 text-white' 
+              activeTab === 'EXPENSE'
+                ? 'bg-red-600 text-white'
                 : 'bg-[#1e2126] text-gray-400 hover:text-white'
             }`}
           >
@@ -261,15 +262,16 @@ export default function CategoriesPage() {
           <button
             onClick={() => setActiveTab('INCOME')}
             className={`px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2 ${
-              activeTab === 'INCOME' 
-                ? 'bg-green-600 text-white' 
+              activeTab === 'INCOME'
+                ? 'bg-green-600 text-white'
                 : 'bg-[#1e2126] text-gray-400 hover:text-white'
             }`}
           >
             <TrendingUp size={16} />
             Receitas
           </button>
-        </div>
+          </div>
+        </Card>
       )}
 
       {/* Info sobre categoria padrão */}


### PR DESCRIPTION
## Summary
- padroniza cor de borda dos formulários de contas e usuários
- adiciona highlight azul para linhas editáveis
- coloca filtros de categorias dentro de card

## Testing
- `npm test` *(fails: DATABASE_URL missing)*

------
https://chatgpt.com/codex/tasks/task_e_684812ccd5988330a1df1773b01f2528