### PR TITLE
Fix account and user permissions

### DIFF
--- a/backend/src/controllers/company.controller.ts
+++ b/backend/src/controllers/company.controller.ts
@@ -11,10 +11,10 @@ const prisma = new PrismaClient();
  */
 function getUserContext(req: Request): { role: string; companyId: number; userId: number } {
   // @ts-ignore — preenchido pelo authMiddleware
-  return { 
+  return {
     role: req.user.role as string,
     companyId: req.user.companyId as number,
-    userId: req.user.id as number
+    userId: req.user.userId as number
   };
 }
 

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -90,6 +90,16 @@ export const createUser = async (req: Request, res: Response) => {
 export const getUsers = async (req: Request, res: Response) => {
   const { role, companyId, userId: me } = getUserContext(req);
 
+  let filterCompanyId: number | undefined = undefined;
+
+  if (role === 'ADMIN' && req.query.companyId !== undefined) {
+    const parsed = Number(req.query.companyId);
+    if (isNaN(parsed)) {
+      return res.status(400).json({ error: 'companyId inválido.' });
+    }
+    filterCompanyId = parsed;
+  }
+
   try {
     let users;
     
@@ -110,9 +120,9 @@ export const getUsers = async (req: Request, res: Response) => {
       }
     };
 
-    // ADMIN pode ver todos os usuários
+    // ADMIN pode ver todos os usuários (com filtro opcional por empresa)
     if (role === 'ADMIN') {
-      users = await UserService.listUsers(baseSelect, companyId);
+      users = await UserService.listUsers(baseSelect, filterCompanyId);
     }
     // SUPERUSER vê usuários da mesma empresa
     else if (role === 'SUPERUSER') {

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -94,15 +94,18 @@ export default class UserService {
    */
   static async listUsers<T extends Prisma.UserFindManyArgs>(
     args: T,
-    companyId: number
+    companyId?: number
   ): Promise<Prisma.UserGetPayload<T>[]> {
-    // Adicionar filtro de empresa ao args.where existente
-    const whereWithCompany = {
-      ...args.where,
-      companies: {
-        some: { companyId }
-      }
-    };
+    let whereWithCompany = args.where || {};
+
+    if (companyId !== undefined) {
+      whereWithCompany = {
+        ...whereWithCompany,
+        companies: {
+          some: { companyId }
+        }
+      };
+    }
 
     const updatedArgs = {
       ...args,


### PR DESCRIPTION
## Summary
- fix context extraction to use `userId`
- allow listing users from all companies and filter by company for admins
- restrict listing financial accounts to those allowed for the user
- support optional company filter in user list service

## Testing
- `npm test` *(fails: Environment variable not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6848159680f4833099f219d1c9f32baa