### PR TITLE
Fix negative balance flag for transactions

### DIFF
--- a/backend/src/services/financial-transaction.service.ts
+++ b/backend/src/services/financial-transaction.service.ts
@@ -119,8 +119,8 @@ export default class FinancialTransactionService {
       for (const accountId of accountsToLock) {
         try {
           const result = await tx.$queryRaw`
-            SELECT id, name, balance, "isActive", "companyId"
-            FROM "FinancialAccount" 
+            SELECT id, name, balance, "isActive", "companyId", "allowNegativeBalance"
+            FROM "FinancialAccount"
             WHERE id = ${accountId}
             FOR UPDATE NOWAIT
           `;


### PR DESCRIPTION
## Summary
- include `allowNegativeBalance` field when locking accounts in `FinancialTransactionService`

## Testing
- `npm test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68481e92b300833090cd0a4767de7e2c