### PR TITLE
Add user feature permissions

### DIFF
--- a/backend/prisma/migrations/20250701120000_user_feature_permissions/migration.sql
+++ b/backend/prisma/migrations/20250701120000_user_feature_permissions/migration.sql
@@ -1,0 +1,3 @@
+-- Add columns for feature permissions
+ALTER TABLE "User" ADD COLUMN "manageFinancialAccounts" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "manageFinancialCategories" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,8 @@ model User {
   password            String
   name                String
   role                Role                  @default(USER)
+  manageFinancialAccounts   Boolean              @default(false)
+  manageFinancialCategories Boolean              @default(false)
   companies           UserCompany[]
   createdAt           DateTime              @default(now())
   updatedAt           DateTime              @updatedAt

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -135,6 +135,8 @@ export async function login(req: Request, res: Response) {
         name: user.name,
         email: user.email,
         role: user.role,
+        manageFinancialAccounts: user.manageFinancialAccounts,
+        manageFinancialCategories: user.manageFinancialCategories,
         company: {
           id: companyId,
           name: companyName
@@ -228,6 +230,8 @@ export async function getCurrentUser(req: Request, res: Response) {
         name: true,
         email: true,
         role: true,
+        manageFinancialAccounts: true,
+        manageFinancialCategories: true,
         companies: {
           take: 1,
           select: {
@@ -254,6 +258,8 @@ export async function getCurrentUser(req: Request, res: Response) {
         name: user.name,
         email: user.email,
         role: user.role,
+        manageFinancialAccounts: user.manageFinancialAccounts,
+        manageFinancialCategories: user.manageFinancialCategories,
         company: company ? {
           id: company.id,
           name: company.name

--- a/backend/src/middlewares/feature-permission.middleware.ts
+++ b/backend/src/middlewares/feature-permission.middleware.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+
+export type FeaturePermission = 'FINANCIAL_ACCOUNTS' | 'FINANCIAL_CATEGORIES';
+
+export function requireFeaturePermission(permission: FeaturePermission) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // @ts-ignore - auth middleware acrescenta
+    const { role, manageFinancialAccounts, manageFinancialCategories } = req.user;
+
+    if (role === 'ADMIN' || role === 'SUPERUSER') {
+      return next();
+    }
+
+    if (permission === 'FINANCIAL_ACCOUNTS' && manageFinancialAccounts) {
+      return next();
+    }
+
+    if (permission === 'FINANCIAL_CATEGORIES' && manageFinancialCategories) {
+      return next();
+    }
+
+    return res.status(403).json({ error: 'Acesso negado' });
+  };
+}

--- a/backend/src/routes/financial.routes.ts
+++ b/backend/src/routes/financial.routes.ts
@@ -1,4 +1,5 @@
 import { requireAccountAccess, requireTransactionAccountAccess } from '../middlewares/financial-access.middleware';
+import { requireFeaturePermission } from '../middlewares/feature-permission.middleware';
 import { Router } from 'express';
 import { validate } from '../middlewares/validate.middleware';
 import {
@@ -65,27 +66,27 @@ const router = Router();
 router.get('/defaults', getCompanyDefaults);
 
 // Rotas de Contas Financeiras
-router.post('/accounts', validate(createAccountSchema), createAccount);
-router.get('/accounts', validate(listAccountsSchema), getAccounts);
-router.get('/accounts/:id', requireAccountAccess(), getAccountById); // ✅ MIDDLEWARE
-router.put('/accounts/:id', requireAccountAccess(), validate(updateAccountSchema), updateAccount); // ✅ MIDDLEWARE
-router.delete('/accounts/:id', requireAccountAccess(), deleteAccount); // ✅ MIDDLEWARE
-router.post('/accounts/:id/adjust-balance', requireAccountAccess(), adjustBalance); // ✅ MIDDLEWARE
+router.post('/accounts', requireFeaturePermission('FINANCIAL_ACCOUNTS'), validate(createAccountSchema), createAccount);
+router.get('/accounts', requireFeaturePermission('FINANCIAL_ACCOUNTS'), validate(listAccountsSchema), getAccounts);
+router.get('/accounts/:id', requireFeaturePermission('FINANCIAL_ACCOUNTS'), requireAccountAccess(), getAccountById); // ✅ MIDDLEWARE
+router.put('/accounts/:id', requireFeaturePermission('FINANCIAL_ACCOUNTS'), requireAccountAccess(), validate(updateAccountSchema), updateAccount); // ✅ MIDDLEWARE
+router.delete('/accounts/:id', requireFeaturePermission('FINANCIAL_ACCOUNTS'), requireAccountAccess(), deleteAccount); // ✅ MIDDLEWARE
+router.post('/accounts/:id/adjust-balance', requireFeaturePermission('FINANCIAL_ACCOUNTS'), requireAccountAccess(), adjustBalance); // ✅ MIDDLEWARE
 
 // Gerenciar conta padrão
 router.post('/accounts/:id/set-default', requireAccountAccess(), setDefaultAccount); // ✅ MIDDLEWARE
 router.delete('/accounts/:id/set-default', requireAccountAccess(), unsetDefaultAccount); // ✅ MIDDLEWARE
 
 // Rotas de Categorias Financeiras
-router.post('/categories', validate(createCategorySchema), createCategory);
-router.get('/categories', validate(listCategoriesSchema), getCategories);
-router.get('/categories/:id', getCategoryById);
-router.put('/categories/:id', validate(updateCategorySchema), updateCategory);
-router.delete('/categories/:id', deleteCategory);
+router.post('/categories', requireFeaturePermission('FINANCIAL_CATEGORIES'), validate(createCategorySchema), createCategory);
+router.get('/categories', requireFeaturePermission('FINANCIAL_CATEGORIES'), validate(listCategoriesSchema), getCategories);
+router.get('/categories/:id', requireFeaturePermission('FINANCIAL_CATEGORIES'), getCategoryById);
+router.put('/categories/:id', requireFeaturePermission('FINANCIAL_CATEGORIES'), validate(updateCategorySchema), updateCategory);
+router.delete('/categories/:id', requireFeaturePermission('FINANCIAL_CATEGORIES'), deleteCategory);
 
 // Gerenciar categoria padrão
-router.post('/categories/:id/set-default', setDefaultCategory);
-router.delete('/categories/:id/set-default', unsetDefaultCategory);
+router.post('/categories/:id/set-default', requireFeaturePermission('FINANCIAL_CATEGORIES'), setDefaultCategory);
+router.delete('/categories/:id/set-default', requireFeaturePermission('FINANCIAL_CATEGORIES'), unsetDefaultCategory);
 
 // ✅ ROTA DE AUTOCOMPLETE - DEVE VIR ANTES DAS ROTAS COM :id
 router.get('/transactions/autocomplete', validate(autocompleteQuerySchema), getTransactionAutocomplete);

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -12,6 +12,8 @@ export interface CreateUserParams {
   name: string;
   role: Role;
   companyId: number;
+  manageFinancialAccounts?: boolean;
+  manageFinancialCategories?: boolean;
 }
 
 export default class UserService {
@@ -27,7 +29,7 @@ export default class UserService {
    * Versão simplificada: um usuário pertence a apenas uma empresa.
    */
   static async createUser(params: CreateUserParams): Promise<Omit<User, 'password'>> {
-    const { email, password, name, role, companyId } = params;
+    const { email, password, name, role, companyId, manageFinancialAccounts = false, manageFinancialCategories = false } = params;
     const hashed = await this.hashPassword(password);
 
     // Verificar se o usuário já tem alguma associação com empresa
@@ -48,10 +50,10 @@ export default class UserService {
       const user = existingUser 
         ? await tx.user.update({
             where: { id: existingUser.id },
-            data: { name, role, password: hashed }
+            data: { name, role, password: hashed, manageFinancialAccounts, manageFinancialCategories }
           })
         : await tx.user.create({
-            data: { email, password: hashed, name, role }
+            data: { email, password: hashed, name, role, manageFinancialAccounts, manageFinancialCategories }
           });
 
       // Criar a associação com a empresa (única)

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ type MenuItem = {
   subItems: SubMenuItem[]; // Todos terão pelo menos um subitem
   requiredRole?: 'ADMIN' | 'SUPERUSER' | 'USER'; // ✅ NOVO: Role mínimo necessário
   allowedRoles?: ('ADMIN' | 'SUPERUSER' | 'USER')[]; // ✅ NOVO: Roles específicos permitidos
+  requiredPermission?: 'FINANCIAL_ACCOUNTS' | 'FINANCIAL_CATEGORIES';
 };
 
 // Tipo para título de seção
@@ -46,6 +47,7 @@ interface SidebarProps {
 
 export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
   const { userRole } = useAuth(); // ✅ OBTER O ROLE DO USUÁRIO
+  const { hasAppPermission } = usePermissions();
   
   // Obtém o estado salvo no localStorage ou usa o padrão
   const getSavedCollapsedState = () => {
@@ -84,6 +86,10 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
     
     // Para itens de menu
     const menuItem = item as MenuItem;
+
+    if (menuItem.requiredPermission && !hasAppPermission(menuItem.requiredPermission)) {
+      return false;
+    }
     
     // Se tem roles específicos permitidos, verificar se o usuário está na lista
     if (menuItem.allowedRoles) {
@@ -144,6 +150,7 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       subItems: [
         { label: 'Contas', href: '/financial/accounts'},
       ],
+      requiredPermission: 'FINANCIAL_ACCOUNTS'
     },
     {
       icon: <Receipt size={20} />,
@@ -161,6 +168,7 @@ export function Sidebar({ onToggle, isCollapsed }: SidebarProps) {
       subItems: [
         { label: 'Categorias', href: '/financial/categories' },
       ],
+      requiredPermission: 'FINANCIAL_CATEGORIES'
     },
     {
       title: 'Relatórios',

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -9,6 +9,8 @@ interface User {
   name: string;
   email: string;
   role: string;
+  manageFinancialAccounts?: boolean;
+  manageFinancialCategories?: boolean;
   company?: {
     id: number;
     name: string;
@@ -26,6 +28,8 @@ interface AuthContextData {
   companyId: number | null;
   userName: string | null;
   companyName: string | null;
+  manageFinancialAccounts: boolean;
+  manageFinancialCategories: boolean;
   refreshToken: () => Promise<boolean>;
 }
 
@@ -239,18 +243,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ 
-        token, 
-        user, 
-        login, 
-        logout, 
+      value={{
+        token,
+        user,
+        login,
+        logout,
         refreshToken,
         isLoading,
         userRole: user?.role || null,
         userId: user?.id || null,
         companyId: user?.company?.id || null,
         userName: user?.name || null,
-        companyName: user?.company?.name || null
+        companyName: user?.company?.name || null,
+        manageFinancialAccounts: user?.manageFinancialAccounts || false,
+        manageFinancialCategories: user?.manageFinancialCategories || false
       }}
     >
       {children}

--- a/frontend/hooks/usePermissions.ts
+++ b/frontend/hooks/usePermissions.ts
@@ -10,7 +10,7 @@ interface PermissionConfig {
 }
 
 export function usePermissions() {
-  const { userRole } = useAuth();
+  const { userRole, manageFinancialAccounts, manageFinancialCategories } = useAuth();
 
   // ✅ HIERARQUIA DE ROLES
   const roleHierarchy: Record<UserRole, number> = {
@@ -54,6 +54,13 @@ export function usePermissions() {
     return true;
   };
 
+  const hasAppPermission = (perm: 'FINANCIAL_ACCOUNTS' | 'FINANCIAL_CATEGORIES'): boolean => {
+    if (hasRole('ADMIN') || hasRole('SUPERUSER')) return true;
+    if (perm === 'FINANCIAL_ACCOUNTS') return manageFinancialAccounts || false;
+    if (perm === 'FINANCIAL_CATEGORIES') return manageFinancialCategories || false;
+    return false;
+  };
+
   // ✅ VERIFICAÇÕES ESPECÍFICAS PARA FUNCIONALIDADES DO SISTEMA
   const canManageCompanies = (): boolean => {
     return hasRole('ADMIN');
@@ -76,11 +83,13 @@ export function usePermissions() {
   };
 
   const canManageFinancialAccounts = (): boolean => {
-    return hasRole('USER'); // Todos podem gerenciar contas financeiras
+    if (hasRole('ADMIN') || hasRole('SUPERUSER')) return true;
+    return manageFinancialAccounts || false;
   };
 
   const canManageCategories = (): boolean => {
-    return hasRole('USER'); // Todos podem gerenciar categorias
+    if (hasRole('ADMIN') || hasRole('SUPERUSER')) return true;
+    return manageFinancialCategories || false;
   };
 
   // ✅ VERIFICAR SE É ADMIN
@@ -127,6 +136,7 @@ export function usePermissions() {
     canCreateTransactions,
     canManageFinancialAccounts,
     canManageCategories,
+    hasAppPermission,
     
     // Verificações de tipo de usuário
     isAdmin,

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -21,6 +21,8 @@ interface User {
   name: string
   email: string
   role: string
+  manageFinancialAccounts?: boolean
+  manageFinancialCategories?: boolean
   companies: {
     company: {
       id: number
@@ -56,7 +58,9 @@ export default function UsersPage() {
     email: '',
     password: '',
     newRole: 'USER',
-    companyId: ''
+    companyId: '',
+    manageFinancialAccounts: false,
+    manageFinancialCategories: false
   });
 
   // ✅ ESTADOS PARA PERMISSÕES DE CONTAS
@@ -116,7 +120,9 @@ export default function UsersPage() {
       email: '',
       password: '',
       newRole: 'USER',
-      companyId: companies.length > 0 ? companies[0].id.toString() : ''
+      companyId: companies.length > 0 ? companies[0].id.toString() : '',
+      manageFinancialAccounts: false,
+      manageFinancialCategories: false
     });
     // ✅ RESETAR PERMISSÕES
     setSelectedAccountIds([]);
@@ -131,7 +137,9 @@ export default function UsersPage() {
       email: user.email,
       password: '',
       newRole: user.role,
-      companyId: user.companies[0]?.company.id.toString() || ''
+      companyId: user.companies[0]?.company.id.toString() || '',
+      manageFinancialAccounts: user.manageFinancialAccounts || false,
+      manageFinancialCategories: user.manageFinancialCategories || false
     });
     // ✅ PERMISSÕES SERÃO CARREGADAS PELO COMPONENTE AccountPermissionsManager
     setSelectedAccountIds([]);
@@ -147,7 +155,9 @@ export default function UsersPage() {
       email: '',
       password: '',
       newRole: 'USER',
-      companyId: ''
+      companyId: '',
+      manageFinancialAccounts: false,
+      manageFinancialCategories: false
     });
     // ✅ LIMPAR PERMISSÕES
     setSelectedAccountIds([]);
@@ -212,9 +222,12 @@ export default function UsersPage() {
       if (editingUser) {
         // ✅ EDIÇÃO - apenas dados básicos, permissões são gerenciadas separadamente
         const { password, ...updateDataWithoutPassword } = formData;
-        const updateData = formData.password 
+        const updateData = formData.password
           ? { ...formData, companyId: formData.companyId ? Number(formData.companyId) : null }
           : { ...updateDataWithoutPassword, companyId: formData.companyId ? Number(formData.companyId) : null };
+
+        updateData.manageFinancialAccounts = formData.manageFinancialAccounts;
+        updateData.manageFinancialCategories = formData.manageFinancialCategories;
 
         await api.put(`/users/${editingUser.id}`, updateData);
         
@@ -238,6 +251,8 @@ export default function UsersPage() {
           password: formData.password,
           newRole: formData.newRole,
           companyId: Number(formData.companyId),
+          manageFinancialAccounts: formData.manageFinancialAccounts,
+          manageFinancialCategories: formData.manageFinancialCategories,
         };
 
         // ✅ ADICIONAR PERMISSÕES APENAS PARA USER
@@ -441,6 +456,28 @@ export default function UsersPage() {
                     {companiesError || 'Nenhuma empresa disponível'}
                   </div>
                 )}
+              </div>
+
+              {/* Permissões de Funcionalidades */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <label className="flex items-center gap-2 text-sm text-gray-300">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={formData.manageFinancialAccounts}
+                    onChange={(e) => setFormData({...formData, manageFinancialAccounts: e.target.checked})}
+                  />
+                  Gerenciar Contas Financeiras
+                </label>
+                <label className="flex items-center gap-2 text-sm text-gray-300">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={formData.manageFinancialCategories}
+                    onChange={(e) => setFormData({...formData, manageFinancialCategories: e.target.checked})}
+                  />
+                  Gerenciar Categorias Financeiras
+                </label>
               </div>
 
               {/* ✅ SEÇÃO DE PERMISSÕES DE CONTAS (apenas para USER) */}

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
+import { PageGuard } from '@/components/ui/AccessGuard';
 import { 
   Plus, CreditCard, Edit2, Trash2, Settings,
   Star, StarOff, AlertTriangle, MinusCircle, HelpCircle
@@ -30,7 +31,7 @@ interface Account {
   updatedAt: string;
 }
 
-export default function AccountsPage() {
+function AccountsPageInner() {
   const confirmation = useConfirmation();
   const { addToast } = useToast();
 
@@ -848,5 +849,13 @@ export default function AccountsPage() {
         loading={confirmation.loading}
       />
     </DashboardLayout>
+  );
+}
+
+export default function AccountsPage() {
+  return (
+    <PageGuard requiredRole="USER" requiredPermission="FINANCIAL_ACCOUNTS">
+      <AccountsPageInner />
+    </PageGuard>
   );
 }

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
+import { PageGuard } from '@/components/ui/AccessGuard';
 import { Plus, Tag, Edit2, Trash2, TrendingUp, TrendingDown, Star, StarOff } from 'lucide-react';
 import api from '@/lib/api';
 
@@ -26,7 +27,7 @@ interface Category {
   _count?: { children: number };
 }
 
-export default function CategoriesPage() {
+function CategoriesPageInner() {
   const confirmation = useConfirmation();
   const { addToast } = useToast();
 
@@ -728,5 +729,13 @@ export default function CategoriesPage() {
         loading={confirmation.loading}
       />
     </DashboardLayout>
+  );
+}
+
+export default function CategoriesPage() {
+  return (
+    <PageGuard requiredRole="USER" requiredPermission="FINANCIAL_CATEGORIES">
+      <CategoriesPageInner />
+    </PageGuard>
   );
 }


### PR DESCRIPTION
## Summary
- allow setting permissions on the User model for managing financial accounts and categories
- enforce feature permissions in routes via new middleware
- expose permissions in auth responses and context
- hide sidebar items when permission is missing
- protect accounts and categories pages and add controls in user form

## Testing
- `npm test` (fails: DATABASE_URL missing)
- `npm test` in frontend (no test script)

------
https://chatgpt.com/codex/tasks/task_e_6848488df64483308c6e1ea68397d4ab