### PR TITLE
Fix login rate limit for dev

### DIFF
--- a/backend/src/middlewares/rate-limit.middleware.ts
+++ b/backend/src/middlewares/rate-limit.middleware.ts
@@ -208,10 +208,15 @@ export const loginRateLimiter = {
  * Middleware específico para proteção de login
  */
 export async function loginRateLimitMiddleware(
-  req: Request, 
-  res: Response, 
+  req: Request,
+  res: Response,
   next: NextFunction
 ) {
+  // Skip login rate limiting entirely in development
+  if (process.env.NODE_ENV === 'development') {
+    return next();
+  }
+
   const email = req.body.email?.toLowerCase?.();
   const ip = getClientIP(req);
   


### PR DESCRIPTION
## Summary
- skip login rate limiting when running in development mode

## Testing
- `npm test --prefix backend` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68489749560483309dd936eded41479b