### PR TITLE
Fix account permissions forms

### DIFF
--- a/backend/src/validators/user-account-access.validator.ts
+++ b/backend/src/validators/user-account-access.validator.ts
@@ -44,6 +44,8 @@ export const userCreationWithPermissionsSchema = z.object({
   name: z.string().min(1, { message: 'Nome é obrigatório.' }),
   companyId: z.number({ invalid_type_error: 'companyId deve ser um número.' }),
   newRole: z.enum(['ADMIN', 'SUPERUSER', 'USER']).optional(),
+  manageFinancialAccounts: z.boolean().optional(),
+  manageFinancialCategories: z.boolean().optional(),
   
   // Novos campos para permissões (opcionais)
   accountPermissions: z.object({

--- a/backend/src/validators/user.validator.ts
+++ b/backend/src/validators/user.validator.ts
@@ -5,7 +5,9 @@ export const createUserSchema = z.object({
   password: z.string().nonempty({ message: 'Password é obrigatório.' }),
   name: z.string().min(1, { message: 'Nome é obrigatório.' }),
   companyId: z.number({ invalid_type_error: 'companyId deve ser um número.' }),
-  newRole: z.enum(['ADMIN', 'SUPERUSER', 'USER']).optional()
+  newRole: z.enum(['ADMIN', 'SUPERUSER', 'USER']).optional(),
+  manageFinancialAccounts: z.boolean().optional(),
+  manageFinancialCategories: z.boolean().optional()
 });
 
 export const updateUserSchema = z
@@ -14,7 +16,9 @@ export const updateUserSchema = z
     password: z.string().nonempty({ message: 'Password não pode ser vazio.' }).optional(),
     name: z.string().min(1, { message: 'Nome é obrigatório.' }).optional(),
     companyId: z.number({ invalid_type_error: 'companyId deve ser um número.' }).optional(),
-    newRole: z.enum(['ADMIN', 'SUPERUSER', 'USER']).optional()
+    newRole: z.enum(['ADMIN', 'SUPERUSER', 'USER']).optional(),
+    manageFinancialAccounts: z.boolean().optional(),
+    manageFinancialCategories: z.boolean().optional()
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: 'Ao menos um campo deve ser fornecido para atualização.'

--- a/frontend/components/admin/AccountPermissionsManager.tsx
+++ b/frontend/components/admin/AccountPermissionsManager.tsx
@@ -80,10 +80,14 @@ export default function AccountPermissionsManager({
 
   async function fetchCurrentAccess() {
     if (!userId) return;
-    
+
     const permissions = await fetchUserPermissions(userId);
     if (permissions) {
       setCurrentAccess(permissions);
+      const accessibleIds = permissions.accounts
+        .filter(acc => acc.hasAccess)
+        .map(acc => acc.id);
+      onPermissionsChange(accessibleIds, permissions.hasFullAccess);
     }
   }
 


### PR DESCRIPTION
## Summary
- save manage financial flags when creating or updating user
- show user existing account permissions in edit form

## Testing
- `npm test` *(fails: Environment variable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489a95e06c83308b3d2daf6bf32211