### PR TITLE
Melhorias no cadastro de usuários

### DIFF
--- a/frontend/components/admin/AccountPermissionsManager.tsx
+++ b/frontend/components/admin/AccountPermissionsManager.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '@/components/ui/ToastContext';
 import { useAccountPermissions } from '@/hooks/useAccountPermissions';
-import { CreditCard, Check, Lock, Users, AlertCircle } from 'lucide-react';
+import { CreditCard, Check, Users, AlertCircle } from 'lucide-react';
 import api from '@/lib/api';
 
 interface Account {
@@ -245,18 +245,6 @@ export default function AccountPermissionsManager({
                           {formatAccountType(account.type)}
                         </span>
                         
-                        {/* Informações da Permissão Atual */}
-                        {currentAccountAccess && showCurrentPermissions && (
-                          <div className="text-xs text-gray-500">
-                            {currentAccountAccess.hasAccess ? (
-                              <span className="text-green-400">
-                                Acesso desde {currentAccountAccess.grantedAt && formatDate(currentAccountAccess.grantedAt)}
-                              </span>
-                            ) : (
-                              <span className="text-gray-500">Sem acesso</span>
-                            )}
-                          </div>
-                        )}
                       </div>
                     </div>
                   </label>
@@ -267,43 +255,6 @@ export default function AccountPermissionsManager({
         </div>
       )}
 
-      {/* Resumo das Permissões Atuais (apenas para edição) */}
-      {userId && currentAccess && showCurrentPermissions && (
-        <div className="p-3 bg-blue-900/20 border border-blue-600 rounded-lg">
-          <div className="flex items-center gap-2 mb-2">
-            <Lock size={14} className="text-blue-400" />
-            <span className="text-sm font-medium text-blue-300">Permissões Atuais</span>
-          </div>
-          <div className="grid grid-cols-2 gap-4 text-xs">
-            <div>
-              <span className="text-blue-200">Total de contas:</span>
-              <div className="font-medium text-white">{currentAccess.totalAccounts}</div>
-            </div>
-            <div>
-              <span className="text-blue-200">Contas acessíveis:</span>
-              <div className="font-medium text-white">{currentAccess.accessibleAccounts}</div>
-            </div>
-          </div>
-          {currentAccess.hasFullAccess && (
-            <div className="mt-2 px-2 py-1 bg-green-700 text-green-100 text-xs rounded">
-              Acesso total ativo
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Warning para usuário sem permissões */}
-      {selectedCount === 0 && (
-        <div className="p-3 bg-yellow-900/20 border border-yellow-600 rounded-lg">
-          <div className="flex items-start gap-2">
-            <AlertCircle size={16} className="text-yellow-400 mt-0.5 flex-shrink-0" />
-            <div className="text-sm text-yellow-200">
-              <strong>Atenção:</strong> Usuário não terá acesso a funcionalidades financeiras. 
-              Dashboard, transações e relatórios ficarão vazios até que permissões sejam concedidas.
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -39,7 +39,7 @@ interface Company {
 
 export default function UsersPage() {
   const confirmation = useConfirmation();
-  const { userRole } = useAuth();
+  const { userRole, companyId, companyName } = useAuth();
   const { canManageUsers, isAdmin } = usePermissions();
   const { addToast } = useToast();
 
@@ -120,7 +120,7 @@ export default function UsersPage() {
       email: '',
       password: '',
       newRole: 'USER',
-      companyId: companies.length > 0 ? companies[0].id.toString() : '',
+      companyId: isAdmin() ? (companies.length > 0 ? companies[0].id.toString() : '') : companyId?.toString() || '',
       manageFinancialAccounts: false,
       manageFinancialCategories: false
     });
@@ -220,11 +220,11 @@ export default function UsersPage() {
 
     try {
       if (editingUser) {
-        // ✅ EDIÇÃO - apenas dados básicos, permissões são gerenciadas separadamente
-        const { password, ...updateDataWithoutPassword } = formData;
+        // ✅ EDIÇÃO - empresa não pode ser alterada
+        const { password, companyId: _ignored, ...updateDataWithoutCompany } = formData;
         const updateData = formData.password
-          ? { ...formData, companyId: formData.companyId ? Number(formData.companyId) : null }
-          : { ...updateDataWithoutPassword, companyId: formData.companyId ? Number(formData.companyId) : null };
+          ? { ...updateDataWithoutCompany, password: formData.password }
+          : { ...updateDataWithoutCompany };
 
         updateData.manageFinancialAccounts = formData.manageFinancialAccounts;
         updateData.manageFinancialCategories = formData.manageFinancialCategories;
@@ -392,10 +392,14 @@ export default function UsersPage() {
                 <label className="block text-sm font-medium mb-1 text-gray-300">
                   Empresa {!editingUser && '*'}
                 </label>
-                {companies.length > 0 ? (
+                {editingUser || !isAdmin() ? (
+                  <div className="w-full px-3 py-2 bg-gray-700 border border-gray-600 text-gray-300 rounded-lg">
+                    {editingUser ? editingUser.companies[0]?.company.name : companyName}
+                  </div>
+                ) : companies.length > 0 ? (
                   <select
                     value={formData.companyId}
-                    onChange={(e) => setFormData({...formData, companyId: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
                     className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-[#2563eb]"
                     required={!editingUser}
                     disabled={formLoading}


### PR DESCRIPTION
## Resumo
- oculta o seletor de empresa para não admins
- evita alteração de empresa ao editar
- remove cartões informativos de permissões

## Testes
- `npm test` *(falhou: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6848e6b373288330bdf9cc4f974ee103