### PR TITLE
Ajusta logo do Dashboard

### DIFF
--- a/frontend/components/layout/DashboardLayout.tsx
+++ b/frontend/components/layout/DashboardLayout.tsx
@@ -82,7 +82,7 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
   return (
     <div className="flex flex-col h-screen bg-[#1e2126]">
       {/* Top Navigation com uma borda sutil */}
-      <header className="fixed top-0 left-0 right-0 z-40 bg-[#151921] text-white py-3 px-6 flex justify-between items-center h-[60px] border-b border-gray-700">
+      <header className="fixed top-0 left-0 right-0 z-40 bg-[#151921] text-white py-3 pr-6 pl-2 flex justify-between items-center h-20 border-b border-gray-700">
         <div className="flex items-center space-x-4">
           <Link href="/" className="flex items-center hover:opacity-90">
             <Image
@@ -91,7 +91,7 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
               width={2000}
               height={1000}
               priority
-              className="h-8 w-auto"
+              className="h-20 w-auto"
             />
           </Link>
           <span className="text-white text-lg font-bold font-heading">


### PR DESCRIPTION
## Resumo
- aumenta a altura do logo e o alinha mais à esquerda no `DashboardLayout`

## Testes
- `npm test` *(falha: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848e959344c83308650192f8598ff5b