### PR TITLE
Padroniza botoes de salvar e cancelar

### DIFF
--- a/frontend/pages/admin/companies.tsx
+++ b/frontend/pages/admin/companies.tsx
@@ -10,7 +10,7 @@ import { AccessGuard } from '@/components/ui/AccessGuard'; // ✅ NOVO IMPORT
 import { useToast } from '@/components/ui/ToastContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePermissions } from '@/hooks/usePermissions'; // ✅ NOVO IMPORT
-import { Plus, Building2, Edit2, Trash2 } from 'lucide-react';
+import { Plus, Building2, Edit2, Trash2, Save, X } from 'lucide-react';
 import api from '@/lib/api';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
@@ -154,15 +154,43 @@ export default function CompaniesPage() {
       <AccessGuard allowedRoles={['ADMIN']}>
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-semibold text-white">Empresas</h1>
-          <Button 
-            variant="accent" 
-            onClick={() => showForm ? closeForm() : openNewForm()}
-            className="flex items-center gap-2"
-            disabled={formLoading}
-          >
-            <Plus size={16} />
-            {showForm ? 'Cancelar' : 'Nova Empresa'}
-          </Button>
+          {showForm ? (
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingCompany
+                    ? 'Salvar Alterações'
+                    : 'Criar Empresa'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="accent"
+              onClick={openNewForm}
+              className="flex items-center gap-2"
+              disabled={formLoading}
+            >
+              <Plus size={16} />
+              Nova Empresa
+            </Button>
+          )}
         </div>
 
         {/* Inline form */}

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -13,7 +13,7 @@ import { useConfirmation } from '@/hooks/useConfirmation'
 import { useToast } from '@/components/ui/ToastContext'
 import { usePermissions } from '@/hooks/usePermissions'
 import AccountPermissionsManager from '@/components/admin/AccountPermissionsManager'
-import { Plus, Users, Edit2, Trash2, AlertCircle, Building2, Shield } from 'lucide-react'
+import { Plus, Users, Edit2, Trash2, AlertCircle, Building2, Shield, Save, X } from 'lucide-react'
 import api from '@/lib/api'
 
 interface User {
@@ -318,15 +318,43 @@ export default function UsersPage() {
       <AccessGuard requiredRole="SUPERUSER">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-semibold text-white">Usuários</h1>
-          <Button 
-            variant="accent" 
-            onClick={() => showForm ? closeForm() : openNewForm()}
-            className="flex items-center gap-2"
-            disabled={formLoading}
-          >
-            <Plus size={16} />
-            {showForm ? 'Cancelar' : 'Novo Usuário'}
-          </Button>
+          {showForm ? (
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading || (!editingUser && companies.length === 0)}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingUser
+                    ? 'Salvar Alterações'
+                    : 'Criar Usuário'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="accent"
+              onClick={openNewForm}
+              className="flex items-center gap-2"
+              disabled={formLoading}
+            >
+              <Plus size={16} />
+              Novo Usuário
+            </Button>
+          )}
         </div>
 
 

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -11,9 +11,10 @@ import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
 import { PageGuard } from '@/components/ui/AccessGuard';
-import { 
+import {
   Plus, CreditCard, Edit2, Trash2, Settings,
-  Star, StarOff, AlertTriangle, MinusCircle, HelpCircle
+  Star, StarOff, AlertTriangle, MinusCircle, HelpCircle,
+  Save, X
 } from 'lucide-react';
 import api from '@/lib/api';
 
@@ -389,15 +390,43 @@ function AccountsPageInner() {
 
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold text-white">Contas Financeiras</h1>
-        <Button 
-          variant="accent" 
-          onClick={() => showForm ? closeForm() : openNewForm()}
-          className="flex items-center gap-2"
-          disabled={formLoading}
-        >
-          <Plus size={16} />
-          {showForm ? 'Cancelar' : 'Nova Conta'}
-        </Button>
+        {showForm ? (
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeForm}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <X size={16} />
+              Cancelar
+            </Button>
+            <Button
+              variant="accent"
+              onClick={handleSubmit}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {formLoading
+                ? 'Salvando...'
+                : editingAccount
+                  ? 'Salvar Alterações'
+                  : 'Criar Conta'}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="accent"
+            onClick={openNewForm}
+            className="flex items-center gap-2"
+            disabled={formLoading}
+          >
+            <Plus size={16} />
+            Nova Conta
+          </Button>
+        )}
       </div>
 
       {/* Filtros */}

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -10,7 +10,7 @@ import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
 import { PageGuard } from '@/components/ui/AccessGuard';
-import { Plus, Tag, Edit2, Trash2, TrendingUp, TrendingDown, Star, StarOff } from 'lucide-react';
+import { Plus, Tag, Edit2, Trash2, TrendingUp, TrendingDown, Star, StarOff, Save, X } from 'lucide-react';
 import api from '@/lib/api';
 
 interface Category {
@@ -234,15 +234,43 @@ function CategoriesPageInner() {
 
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold text-white">Categorias Financeiras</h1>
-        <Button 
-          variant="accent" 
-          onClick={() => showForm ? closeForm() : openNewForm()}
-          className="flex items-center gap-2"
-          disabled={formLoading}
-        >
-          <Plus size={16} />
-          {showForm ? 'Cancelar' : 'Nova Categoria'}
-        </Button>
+        {showForm ? (
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeForm}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <X size={16} />
+              Cancelar
+            </Button>
+            <Button
+              variant="accent"
+              onClick={handleSubmit}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {formLoading
+                ? 'Salvando...'
+                : editingCategory
+                  ? 'Salvar Alterações'
+                  : 'Criar Categoria'}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="accent"
+            onClick={openNewForm}
+            className="flex items-center gap-2"
+            disabled={formLoading}
+          >
+            <Plus size={16} />
+            Nova Categoria
+          </Button>
+        )}
       </div>
 
       {/* Abas de Tipo */}

--- a/frontend/pages/financial/recurring.tsx
+++ b/frontend/pages/financial/recurring.tsx
@@ -7,7 +7,7 @@ import { Input } from '../../components/ui/Input';
 import { Breadcrumb } from '../../components/ui/Breadcrumb';
 import { PageLoader } from '../../components/ui/PageLoader';
 import { useToast } from '../../components/ui/ToastContext';
-import { Plus, Edit2, Trash2, Calendar, DollarSign, Play, Pause, MoreVertical, TrendingUp, TrendingDown } from 'lucide-react';
+import { Plus, Edit2, Trash2, Calendar, DollarSign, Play, Pause, MoreVertical, TrendingUp, TrendingDown, Save, X } from 'lucide-react';
 import api from '../../lib/api';
 
 interface RecurringTransaction {
@@ -465,13 +465,35 @@ export default function FinancialRecurringPage() {
       {showForm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-[#151921] rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto border border-gray-700">
-            <div className="p-6 border-b border-gray-700">
+            <div className="flex items-center justify-between p-6 border-b border-gray-700">
               <h3 className="text-xl font-semibold text-white">
                 {editingId ? 'Editar' : 'Nova'} {formData.type === 'EXPENSE' ? 'Despesa' : 'Receita'} Recorrente
               </h3>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={resetForm}
+                  disabled={formLoading}
+                  className="flex items-center gap-2"
+                >
+                  <X size={16} />
+                  Cancelar
+                </Button>
+                <Button
+                  type="submit"
+                  form="recurring-form"
+                  variant="accent"
+                  disabled={formLoading}
+                  className="flex items-center gap-2"
+                >
+                  <Save size={16} />
+                  {formLoading ? 'Salvando...' : editingId ? 'Atualizar' : 'Criar'}
+                </Button>
+              </div>
             </div>
-            
-            <form onSubmit={handleSubmit} className="p-6 space-y-4">
+
+            <form id="recurring-form" onSubmit={handleSubmit} className="p-6 space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <Input
                   label="Descrição"


### PR DESCRIPTION
## Resumo
- adiciona ícones Save e X aos imports
- exibe ações Cancelar e Salvar no topo dos formulários de cadastros
- aplica padrão nas páginas de contas, categorias, empresas, usuários e transações recorrentes

## Testes
- `npm run build` *(falhou: falta de acesso à rede para baixar fontes)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea57264c83308c80b360a003d7dc