### PR TITLE
Padroniza botoes de salvar e cancelar

### DIFF
--- a/frontend/components/admin/AccountPermissionsManager.tsx
+++ b/frontend/components/admin/AccountPermissionsManager.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '@/components/ui/ToastContext';
 import { useAccountPermissions } from '@/hooks/useAccountPermissions';
-import { CreditCard, Check, Lock, Users, AlertCircle } from 'lucide-react';
+import { CreditCard, Check, Users, AlertCircle } from 'lucide-react';
 import api from '@/lib/api';
 
 interface Account {
@@ -245,18 +245,6 @@ export default function AccountPermissionsManager({
                           {formatAccountType(account.type)}
                         </span>
                         
-                        {/* Informações da Permissão Atual */}
-                        {currentAccountAccess && showCurrentPermissions && (
-                          <div className="text-xs text-gray-500">
-                            {currentAccountAccess.hasAccess ? (
-                              <span className="text-green-400">
-                                Acesso desde {currentAccountAccess.grantedAt && formatDate(currentAccountAccess.grantedAt)}
-                              </span>
-                            ) : (
-                              <span className="text-gray-500">Sem acesso</span>
-                            )}
-                          </div>
-                        )}
                       </div>
                     </div>
                   </label>
@@ -267,43 +255,6 @@ export default function AccountPermissionsManager({
         </div>
       )}
 
-      {/* Resumo das Permissões Atuais (apenas para edição) */}
-      {userId && currentAccess && showCurrentPermissions && (
-        <div className="p-3 bg-blue-900/20 border border-blue-600 rounded-lg">
-          <div className="flex items-center gap-2 mb-2">
-            <Lock size={14} className="text-blue-400" />
-            <span className="text-sm font-medium text-blue-300">Permissões Atuais</span>
-          </div>
-          <div className="grid grid-cols-2 gap-4 text-xs">
-            <div>
-              <span className="text-blue-200">Total de contas:</span>
-              <div className="font-medium text-white">{currentAccess.totalAccounts}</div>
-            </div>
-            <div>
-              <span className="text-blue-200">Contas acessíveis:</span>
-              <div className="font-medium text-white">{currentAccess.accessibleAccounts}</div>
-            </div>
-          </div>
-          {currentAccess.hasFullAccess && (
-            <div className="mt-2 px-2 py-1 bg-green-700 text-green-100 text-xs rounded">
-              Acesso total ativo
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Warning para usuário sem permissões */}
-      {selectedCount === 0 && (
-        <div className="p-3 bg-yellow-900/20 border border-yellow-600 rounded-lg">
-          <div className="flex items-start gap-2">
-            <AlertCircle size={16} className="text-yellow-400 mt-0.5 flex-shrink-0" />
-            <div className="text-sm text-yellow-200">
-              <strong>Atenção:</strong> Usuário não terá acesso a funcionalidades financeiras. 
-              Dashboard, transações e relatórios ficarão vazios até que permissões sejam concedidas.
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/components/layout/DashboardLayout.tsx
+++ b/frontend/components/layout/DashboardLayout.tsx
@@ -84,16 +84,27 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
       {/* Top Navigation com uma borda sutil */}
       <header className="fixed top-0 left-0 right-0 z-40 bg-[#151921] text-white py-3 px-6 flex justify-between items-center h-[60px] border-b border-gray-700">
         <div className="flex items-center space-x-4">
-          <Link href="/" className="flex items-center space-x-2 hover:opacity-90">
-            {/* ✅ LOGO COM COR DINÂMICA */}
-            <div className="text-2xl font-bold text-accent transition-colors duration-200">₹</div>
-            <span className="text-white text-lg font-bold font-heading">Zenit</span>
+          <Link href="/" className="flex items-center hover:opacity-90">
+            <Image
+              src="/assets/images/logo.png"
+              alt="ZENIT"
+              width={2000}
+              height={1000}
+              priority
+              className="h-8 w-auto"
+            />
           </Link>
+          <span className="text-white text-lg font-bold font-heading">
+            {companyName}
+          </span>
         </div>
 
         <div className="flex items-center space-x-3">
-          {/* ✅ SELETOR DE TEMAS */}
-          <ThemeSelector showLabel={false} size="sm" />
+          {/* ✅ SELETOR DE TEMAS (oculto) */}
+          <div className="hidden">
+            <ThemeSelector showLabel={false} size="sm" />
+          </div>
+          <span className="text-sm text-gray-300">{userName}</span>
           
           <div className="relative" ref={userMenuRef}>
             <button 

--- a/frontend/components/layout/DashboardLayout.tsx
+++ b/frontend/components/layout/DashboardLayout.tsx
@@ -82,7 +82,7 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
   return (
     <div className="flex flex-col h-screen bg-[#1e2126]">
       {/* Top Navigation com uma borda sutil */}
-      <header className="fixed top-0 left-0 right-0 z-40 bg-[#151921] text-white py-3 px-6 flex justify-between items-center h-[60px] border-b border-gray-700">
+      <header className="fixed top-0 left-0 right-0 z-40 bg-[#151921] text-white py-3 pr-6 pl-2 flex justify-between items-center h-20 border-b border-gray-700">
         <div className="flex items-center space-x-4">
           <Link href="/" className="flex items-center hover:opacity-90">
             <Image
@@ -91,7 +91,7 @@ export function DashboardLayout({ children, title = 'Dashboard' }: DashboardLayo
               width={2000}
               height={1000}
               priority
-              className="h-8 w-auto"
+              className="h-20 w-auto"
             />
           </Link>
           <span className="text-white text-lg font-bold font-heading">

--- a/frontend/pages/admin/companies.tsx
+++ b/frontend/pages/admin/companies.tsx
@@ -10,7 +10,7 @@ import { AccessGuard } from '@/components/ui/AccessGuard'; // ✅ NOVO IMPORT
 import { useToast } from '@/components/ui/ToastContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePermissions } from '@/hooks/usePermissions'; // ✅ NOVO IMPORT
-import { Plus, Building2, Edit2, Trash2 } from 'lucide-react';
+import { Plus, Building2, Edit2, Trash2, Save, X } from 'lucide-react';
 import api from '@/lib/api';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
@@ -154,15 +154,43 @@ export default function CompaniesPage() {
       <AccessGuard allowedRoles={['ADMIN']}>
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-semibold text-white">Empresas</h1>
-          <Button 
-            variant="accent" 
-            onClick={() => showForm ? closeForm() : openNewForm()}
-            className="flex items-center gap-2"
-            disabled={formLoading}
-          >
-            <Plus size={16} />
-            {showForm ? 'Cancelar' : 'Nova Empresa'}
-          </Button>
+          {showForm ? (
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingCompany
+                    ? 'Salvar Alterações'
+                    : 'Criar Empresa'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="accent"
+              onClick={openNewForm}
+              className="flex items-center gap-2"
+              disabled={formLoading}
+            >
+              <Plus size={16} />
+              Nova Empresa
+            </Button>
+          )}
         </div>
 
         {/* Inline form */}

--- a/frontend/pages/admin/companies.tsx
+++ b/frontend/pages/admin/companies.tsx
@@ -190,25 +190,28 @@ export default function CompaniesPage() {
                 disabled={formLoading}
               />
 
-              <div className="flex gap-3">
-                <Button 
-                  variant="accent" 
-                  onClick={handleSubmit}
-                  disabled={formLoading}
-                >
-                  {formLoading 
-                    ? 'Salvando...' 
-                    : editingCompany 
-                      ? 'Salvar Alterações' 
-                      : 'Criar Empresa'
-                  }
-                </Button>
-                <Button 
-                  variant="outline" 
+              <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
+                <Button
+                  type="button"
+                  variant="outline"
                   onClick={closeForm}
                   disabled={formLoading}
+                  className="flex items-center gap-2"
                 >
                   Cancelar
+                </Button>
+                <Button
+                  variant="accent"
+                  onClick={handleSubmit}
+                  disabled={formLoading}
+                  className="flex items-center gap-2"
+                >
+                  {formLoading
+                    ? 'Salvando...'
+                    : editingCompany
+                      ? 'Salvar Alterações'
+                      : 'Criar Empresa'
+                  }
                 </Button>
               </div>
             </div>

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -13,7 +13,7 @@ import { useConfirmation } from '@/hooks/useConfirmation'
 import { useToast } from '@/components/ui/ToastContext'
 import { usePermissions } from '@/hooks/usePermissions'
 import AccountPermissionsManager from '@/components/admin/AccountPermissionsManager'
-import { Plus, Users, Edit2, Trash2, AlertCircle, Building2, Shield } from 'lucide-react'
+import { Plus, Users, Edit2, Trash2, AlertCircle, Building2, Shield, Save, X } from 'lucide-react'
 import api from '@/lib/api'
 
 interface User {
@@ -318,15 +318,43 @@ export default function UsersPage() {
       <AccessGuard requiredRole="SUPERUSER">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-semibold text-white">Usuários</h1>
-          <Button 
-            variant="accent" 
-            onClick={() => showForm ? closeForm() : openNewForm()}
-            className="flex items-center gap-2"
-            disabled={formLoading}
-          >
-            <Plus size={16} />
-            {showForm ? 'Cancelar' : 'Novo Usuário'}
-          </Button>
+          {showForm ? (
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading || (!editingUser && companies.length === 0)}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingUser
+                    ? 'Salvar Alterações'
+                    : 'Criar Usuário'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="accent"
+              onClick={openNewForm}
+              className="flex items-center gap-2"
+              disabled={formLoading}
+            >
+              <Plus size={16} />
+              Novo Usuário
+            </Button>
+          )}
         </div>
 
 

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -39,7 +39,7 @@ interface Company {
 
 export default function UsersPage() {
   const confirmation = useConfirmation();
-  const { userRole } = useAuth();
+  const { userRole, companyId, companyName } = useAuth();
   const { canManageUsers, isAdmin } = usePermissions();
   const { addToast } = useToast();
 
@@ -120,7 +120,7 @@ export default function UsersPage() {
       email: '',
       password: '',
       newRole: 'USER',
-      companyId: companies.length > 0 ? companies[0].id.toString() : '',
+      companyId: isAdmin() ? (companies.length > 0 ? companies[0].id.toString() : '') : companyId?.toString() || '',
       manageFinancialAccounts: false,
       manageFinancialCategories: false
     });
@@ -220,11 +220,11 @@ export default function UsersPage() {
 
     try {
       if (editingUser) {
-        // ✅ EDIÇÃO - apenas dados básicos, permissões são gerenciadas separadamente
-        const { password, ...updateDataWithoutPassword } = formData;
+        // ✅ EDIÇÃO - empresa não pode ser alterada
+        const { password, companyId: _ignored, ...updateDataWithoutCompany } = formData;
         const updateData = formData.password
-          ? { ...formData, companyId: formData.companyId ? Number(formData.companyId) : null }
-          : { ...updateDataWithoutPassword, companyId: formData.companyId ? Number(formData.companyId) : null };
+          ? { ...updateDataWithoutCompany, password: formData.password }
+          : { ...updateDataWithoutCompany };
 
         updateData.manageFinancialAccounts = formData.manageFinancialAccounts;
         updateData.manageFinancialCategories = formData.manageFinancialCategories;
@@ -392,10 +392,14 @@ export default function UsersPage() {
                 <label className="block text-sm font-medium mb-1 text-gray-300">
                   Empresa {!editingUser && '*'}
                 </label>
-                {companies.length > 0 ? (
+                {editingUser || !isAdmin() ? (
+                  <div className="w-full px-3 py-2 bg-gray-700 border border-gray-600 text-gray-300 rounded-lg">
+                    {editingUser ? editingUser.companies[0]?.company.name : companyName}
+                  </div>
+                ) : companies.length > 0 ? (
                   <select
                     value={formData.companyId}
-                    onChange={(e) => setFormData({...formData, companyId: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
                     className="w-full px-3 py-2 bg-[#1e2126] border border-gray-700 text-white rounded-lg focus:outline-none focus:ring focus:border-[#2563eb]"
                     required={!editingUser}
                     disabled={formLoading}

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -454,25 +454,28 @@ export default function UsersPage() {
                 </div>
               )}
 
-              <div className="flex gap-3 pt-4 border-t border-gray-700">
-                <Button 
-                  variant="accent" 
-                  onClick={handleSubmit}
-                  disabled={formLoading || (!editingUser && companies.length === 0)}
-                >
-                  {formLoading 
-                    ? 'Salvando...' 
-                    : editingUser 
-                      ? 'Salvar Alterações' 
-                      : 'Criar Usuário'
-                  }
-                </Button>
-                <Button 
-                  variant="outline" 
+              <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
+                <Button
+                  type="button"
+                  variant="outline"
                   onClick={closeForm}
                   disabled={formLoading}
+                  className="flex items-center gap-2"
                 >
                   Cancelar
+                </Button>
+                <Button
+                  variant="accent"
+                  onClick={handleSubmit}
+                  disabled={formLoading || (!editingUser && companies.length === 0)}
+                  className="flex items-center gap-2"
+                >
+                  {formLoading
+                    ? 'Salvando...'
+                    : editingUser
+                      ? 'Salvar Alterações'
+                      : 'Criar Usuário'
+                  }
                 </Button>
               </div>
             </div>

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -11,9 +11,10 @@ import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
 import { PageGuard } from '@/components/ui/AccessGuard';
-import { 
+import {
   Plus, CreditCard, Edit2, Trash2, Settings,
-  Star, StarOff, AlertTriangle, MinusCircle, HelpCircle
+  Star, StarOff, AlertTriangle, MinusCircle, HelpCircle,
+  Save, X
 } from 'lucide-react';
 import api from '@/lib/api';
 
@@ -389,15 +390,43 @@ function AccountsPageInner() {
 
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold text-white">Contas Financeiras</h1>
-        <Button 
-          variant="accent" 
-          onClick={() => showForm ? closeForm() : openNewForm()}
-          className="flex items-center gap-2"
-          disabled={formLoading}
-        >
-          <Plus size={16} />
-          {showForm ? 'Cancelar' : 'Nova Conta'}
-        </Button>
+        {showForm ? (
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeForm}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <X size={16} />
+              Cancelar
+            </Button>
+            <Button
+              variant="accent"
+              onClick={handleSubmit}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {formLoading
+                ? 'Salvando...'
+                : editingAccount
+                  ? 'Salvar Alterações'
+                  : 'Criar Conta'}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="accent"
+            onClick={openNewForm}
+            className="flex items-center gap-2"
+            disabled={formLoading}
+          >
+            <Plus size={16} />
+            Nova Conta
+          </Button>
+        )}
       </div>
 
       {/* Filtros */}

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -564,25 +564,28 @@ function AccountsPageInner() {
               </div>
             </div>
 
-            <div className="flex gap-3">
-              <Button 
-                variant="accent" 
-                onClick={handleSubmit}
-                disabled={formLoading}
-              >
-                {formLoading 
-                  ? 'Salvando...' 
-                  : editingAccount 
-                    ? 'Salvar Alterações' 
-                    : 'Criar Conta'
-                }
-              </Button>
-              <Button 
-                variant="outline" 
+            <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
+              <Button
+                type="button"
+                variant="outline"
                 onClick={closeForm}
                 disabled={formLoading}
+                className="flex items-center gap-2"
               >
                 Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                {formLoading
+                  ? 'Salvando...'
+                  : editingAccount
+                    ? 'Salvar Alterações'
+                    : 'Criar Conta'
+                }
               </Button>
             </div>
           </div>
@@ -815,19 +818,20 @@ function AccountsPageInner() {
               </div>
             </div>
 
-            <div className="flex gap-3 p-6 border-t border-gray-700">
-              <Button 
-                variant="outline" 
+            <div className="flex justify-end gap-4 p-6 border-t border-gray-700">
+              <Button
+                type="button"
+                variant="outline"
                 onClick={closeBalanceModal}
-                className="flex-1"
+                className="flex-1 flex items-center gap-2"
                 disabled={formLoading}
               >
                 Cancelar
               </Button>
-              <Button 
+              <Button
                 variant="accent"
                 onClick={handleBalanceAdjust}
-                className="flex-1"
+                className="flex-1 flex items-center gap-2"
                 disabled={formLoading}
               >
                 {formLoading ? 'Ajustando...' : 'Ajustar Saldo'}

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -10,7 +10,7 @@ import { useToast } from '@/components/ui/ToastContext';
 import { ConfirmationModal } from '@/components/ui/ConfirmationModal';
 import { useConfirmation } from '@/hooks/useConfirmation';
 import { PageGuard } from '@/components/ui/AccessGuard';
-import { Plus, Tag, Edit2, Trash2, TrendingUp, TrendingDown, Star, StarOff } from 'lucide-react';
+import { Plus, Tag, Edit2, Trash2, TrendingUp, TrendingDown, Star, StarOff, Save, X } from 'lucide-react';
 import api from '@/lib/api';
 
 interface Category {
@@ -234,15 +234,43 @@ function CategoriesPageInner() {
 
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-semibold text-white">Categorias Financeiras</h1>
-        <Button 
-          variant="accent" 
-          onClick={() => showForm ? closeForm() : openNewForm()}
-          className="flex items-center gap-2"
-          disabled={formLoading}
-        >
-          <Plus size={16} />
-          {showForm ? 'Cancelar' : 'Nova Categoria'}
-        </Button>
+        {showForm ? (
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeForm}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <X size={16} />
+              Cancelar
+            </Button>
+            <Button
+              variant="accent"
+              onClick={handleSubmit}
+              disabled={formLoading}
+              className="flex items-center gap-2"
+            >
+              <Save size={16} />
+              {formLoading
+                ? 'Salvando...'
+                : editingCategory
+                  ? 'Salvar Alterações'
+                  : 'Criar Categoria'}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="accent"
+            onClick={openNewForm}
+            className="flex items-center gap-2"
+            disabled={formLoading}
+          >
+            <Plus size={16} />
+            Nova Categoria
+          </Button>
+        )}
       </div>
 
       {/* Abas de Tipo */}

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -383,25 +383,28 @@ function CategoriesPageInner() {
               />
             </div>
 
-            <div className="flex gap-3">
-              <Button 
-                variant="accent" 
-                onClick={handleSubmit}
-                disabled={formLoading}
-              >
-                {formLoading 
-                  ? 'Salvando...' 
-                  : editingCategory 
-                    ? 'Salvar Alterações' 
-                    : 'Criar Categoria'
-                }
-              </Button>
-              <Button 
-                variant="outline" 
+            <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
+              <Button
+                type="button"
+                variant="outline"
                 onClick={closeForm}
                 disabled={formLoading}
+                className="flex items-center gap-2"
               >
                 Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                {formLoading
+                  ? 'Salvando...'
+                  : editingCategory
+                    ? 'Salvar Alterações'
+                    : 'Criar Categoria'
+                }
               </Button>
             </div>
           </div>

--- a/frontend/pages/financial/recurring.tsx
+++ b/frontend/pages/financial/recurring.tsx
@@ -645,25 +645,25 @@ export default function FinancialRecurringPage() {
                 ></textarea>
               </div>
               
-              <div className="flex gap-3 mt-6">
-                <Button 
-                  type="button" 
-                  variant="outline" 
+              <div className="flex justify-end gap-4 mt-6 pt-6 border-t border-gray-700">
+                <Button
+                  type="button"
+                  variant="outline"
                   onClick={resetForm}
-                  className="flex-1"
+                  className="flex-1 flex items-center gap-2"
                 >
                   Cancelar
                 </Button>
-                <Button 
-                  type="submit" 
+                <Button
+                  type="submit"
                   variant="accent"
                   disabled={formLoading}
-                  className="flex-1"
+                  className="flex-1 flex items-center gap-2"
                 >
-                  {formLoading 
-                    ? 'Salvando...' 
-                    : editingId 
-                      ? 'Atualizar' 
+                  {formLoading
+                    ? 'Salvando...'
+                    : editingId
+                      ? 'Atualizar'
                       : 'Criar'
                   }
                 </Button>

--- a/frontend/pages/financial/recurring.tsx
+++ b/frontend/pages/financial/recurring.tsx
@@ -7,7 +7,7 @@ import { Input } from '../../components/ui/Input';
 import { Breadcrumb } from '../../components/ui/Breadcrumb';
 import { PageLoader } from '../../components/ui/PageLoader';
 import { useToast } from '../../components/ui/ToastContext';
-import { Plus, Edit2, Trash2, Calendar, DollarSign, Play, Pause, MoreVertical, TrendingUp, TrendingDown } from 'lucide-react';
+import { Plus, Edit2, Trash2, Calendar, DollarSign, Play, Pause, MoreVertical, TrendingUp, TrendingDown, Save, X } from 'lucide-react';
 import api from '../../lib/api';
 
 interface RecurringTransaction {
@@ -465,13 +465,35 @@ export default function FinancialRecurringPage() {
       {showForm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-[#151921] rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto border border-gray-700">
-            <div className="p-6 border-b border-gray-700">
+            <div className="flex items-center justify-between p-6 border-b border-gray-700">
               <h3 className="text-xl font-semibold text-white">
                 {editingId ? 'Editar' : 'Nova'} {formData.type === 'EXPENSE' ? 'Despesa' : 'Receita'} Recorrente
               </h3>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={resetForm}
+                  disabled={formLoading}
+                  className="flex items-center gap-2"
+                >
+                  <X size={16} />
+                  Cancelar
+                </Button>
+                <Button
+                  type="submit"
+                  form="recurring-form"
+                  variant="accent"
+                  disabled={formLoading}
+                  className="flex items-center gap-2"
+                >
+                  <Save size={16} />
+                  {formLoading ? 'Salvando...' : editingId ? 'Atualizar' : 'Criar'}
+                </Button>
+              </div>
             </div>
-            
-            <form onSubmit={handleSubmit} className="p-6 space-y-4">
+
+            <form id="recurring-form" onSubmit={handleSubmit} className="p-6 space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <Input
                   label="Descrição"


### PR DESCRIPTION
## Resumo
- adiciona ícones Save e X aos imports
- exibe ações Cancelar e Salvar no topo dos formulários de cadastros
- aplica padrão nas páginas de contas, categorias, empresas, usuários e transações recorrentes

## Testes
- `npm run build` *(falhou: falta de acesso à rede para baixar fontes)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea57264c83308c80b360a003d7dc