### PR TITLE
Adiciona instruções de build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 Zenit Core Financial Management System
 
+## 🚧 Instruções para o Agente
+Estas diretrizes orientam como proceder com novas contribuições.
+
+- Rode sempre `npm run build` para verificar possíveis falhas no código gerado, e já corrigir.
+- Gere mensagens de commit, comentários e PRs todos em português.
+
+
 ## 📋 Visão Geral
 
 O **Zenit Core** é um sistema backend enterprise de gestão financeira multi-tenant, desenvolvido para oferecer controle granular sobre operações financeiras com foco em segurança, integridade de dados e escalabilidade. O sistema foi projetado seguindo padrões enterprise e melhores práticas de desenvolvimento para aplicações financeiras críticas.


### PR DESCRIPTION
## Descrição
Adicionei no `AGENTS.md` orientações para sempre executar `npm run build` e para usar português nas mensagens de commit e PRs.

## Testes realizados
- `npm run build` em `backend` — sucesso
- `npm run build` em `frontend` — falhou ao baixar fontes do Google (sem conexão)


------
https://chatgpt.com/codex/tasks/task_e_68490535f66c83308203569658dbb339