### PR TITLE
Personalizar ícones de exportação do relatório

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
         "next": "^15.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "recharts": "^2.10.4"
+        "recharts": "^2.10.4",
+        "react-icons": "^4.12.0"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.10",

--- a/frontend/pages/financial/reports/financial-account-movement.tsx
+++ b/frontend/pages/financial/reports/financial-account-movement.tsx
@@ -6,10 +6,11 @@ import { Input } from '@/components/ui/Input';
 import { Breadcrumb } from '@/components/ui/Breadcrumb';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { useToast } from '@/components/ui/ToastContext';
-import { 
-  TrendingUp, TrendingDown, Download, Printer, FileText, FileSpreadsheet,
+import {
+  TrendingUp, TrendingDown, Download, Printer,
   Calendar, Filter, ZoomIn, ZoomOut, RotateCcw
 } from 'lucide-react';
+import { FaFilePdf, FaFileExcel } from 'react-icons/fa';
 import api from '@/lib/api';
 import { Roboto_Condensed } from 'next/font/google';
 
@@ -524,14 +525,14 @@ export default function FinancialMovementReport() {
                     className="p-2 hover:bg-[#262b36] rounded transition-colors text-gray-300 hover:text-red-400"
                     title="Exportar PDF"
                   >
-                    <FileText size={16} />
+                    <FaFilePdf size={16} />
                   </button>
                   <button
                     onClick={exportToExcel}
                     className="p-2 hover:bg-[#262b36] rounded transition-colors text-gray-300 hover:text-green-400"
                     title="Exportar Excel"
                   >
-                    <FileSpreadsheet size={16} />
+                    <FaFileExcel size={16} />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Alterações
- Substitui os ícones genéricos nos botões de exportação por `FaFilePdf` e `FaFileExcel`
- Adicionada dependência `react-icons` ao *frontend*

## Testes
- `npm test` em `backend` falhou devido à ausência de `DATABASE_URL`
- `npm test` em `frontend` não está disponível


------
https://chatgpt.com/codex/tasks/task_e_6849064955f48330814d818bd5c4f070