### PR TITLE
Implementar troca de senha obrigatória

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   role                Role                  @default(USER)
   manageFinancialAccounts   Boolean              @default(false)
   manageFinancialCategories Boolean              @default(false)
+  mustChangePassword        Boolean              @default(true)
   companies           UserCompany[]
   createdAt           DateTime              @default(now())
   updatedAt           DateTime              @updatedAt

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -56,7 +56,8 @@ async function main() {
         email: 'admin@equinox.com.br',
         password: hashedPassword,
         name: 'Admin',
-        role: 'ADMIN'
+        role: 'ADMIN',
+        mustChangePassword: false
       }
     });
     console.log('✅ Usuário admin criado:', { id: adminUser.id, email: adminUser.email, role: adminUser.role });

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -137,6 +137,7 @@ export async function login(req: Request, res: Response) {
         role: user.role,
         manageFinancialAccounts: user.manageFinancialAccounts,
         manageFinancialCategories: user.manageFinancialCategories,
+        mustChangePassword: user.mustChangePassword,
         company: {
           id: companyId,
           name: companyName

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -246,7 +246,10 @@ export const updateUser = async (req: Request, res: Response) => {
     const updateData: any = {};
     if (email) updateData.email = email;
     if (name) updateData.name = name;
-    if (password) updateData.password = password;
+    if (password) {
+      updateData.password = password;
+      updateData.mustChangePassword = id === me ? false : true;
+    }
     if (newRole && (role === 'ADMIN' || (role === 'SUPERUSER' && newRole !== 'ADMIN'))) {
       updateData.role = newRole;
     }

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -47,13 +47,28 @@ export default class UserService {
     // Realizar toda a operação em uma transação para garantir consistência
     return prisma.$transaction(async (tx) => {
       // Criar ou atualizar o usuário
-      const user = existingUser 
+      const user = existingUser
         ? await tx.user.update({
             where: { id: existingUser.id },
-            data: { name, role, password: hashed, manageFinancialAccounts, manageFinancialCategories }
+            data: {
+              name,
+              role,
+              password: hashed,
+              manageFinancialAccounts,
+              manageFinancialCategories,
+              mustChangePassword: true
+            }
           })
         : await tx.user.create({
-            data: { email, password: hashed, name, role, manageFinancialAccounts, manageFinancialCategories }
+            data: {
+              email,
+              password: hashed,
+              name,
+              role,
+              manageFinancialAccounts,
+              manageFinancialCategories,
+              mustChangePassword: true
+            }
           });
 
       // Criar a associação com a empresa (única)


### PR DESCRIPTION
## Summary
- obrigar troca de senha no primeiro acesso
- evitar troca para o admin do seed
- sinalizar no login se o usuário precisa alterar a senha
- atualizar lógica de criação e atualização de usuários

## Testing
- `npm test` *(falha: DATABASE_URL ausente)*
- `npm run lint` *(falha: configuração do ESLint não encontrada)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68490d6bce84833095b150e12a2e97b0