### PR TITLE
Forçar troca de senha no primeiro acesso

### DIFF
--- a/frontend/pages/first-access.tsx
+++ b/frontend/pages/first-access.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card } from '@/components/ui/Card'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import api from '@/lib/api'
+
+export default function FirstAccessPage() {
+  const { userId, updateMustChangePassword } = useAuth()
+  const router = useRouter()
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (password !== confirm) {
+      setError('As senhas não coincidem')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await api.put(`/users/${userId}`, { password })
+      updateMustChangePassword(false)
+      router.replace('/')
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Erro ao alterar senha')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#1e2126]">
+      <Card className="w-full max-w-md" headerTitle="Defina sua nova senha">
+        <form onSubmit={handleSubmit}>
+          <Input
+            id="password"
+            label="Nova Senha"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+          <Input
+            id="confirm"
+            label="Confirme a Senha"
+            type="password"
+            value={confirm}
+            onChange={e => setConfirm(e.target.value)}
+            required
+          />
+          {error && <p className="text-red-400 text-sm mb-2">{error}</p>}
+          <Button type="submit" variant="accent" className="w-full" disabled={loading}>
+            {loading ? 'Salvando...' : 'Salvar'}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -22,9 +22,13 @@ export default function LoginPage() {
     setError(null);
     setLoading(true);
     try {
-      await login(email, password);
-      const target = redirect && redirect !== '/' ? redirect : '/';
-      router.replace(target);
+      const userData = await login(email, password);
+      if (userData.mustChangePassword) {
+        router.replace('/first-access');
+      } else {
+        const target = redirect && redirect !== '/' ? redirect : '/';
+        router.replace(target);
+      }
     } catch (err: any) {
       setError(err.response?.data?.error || 'Erro ao fazer login');
     } finally {


### PR DESCRIPTION
## Notas
- Implementado redirecionamento para troca de senha após login quando `mustChangePassword` é verdadeiro
- Criado formulário `first-access` para definir nova senha
- Armazenada flag em `localStorage` e adicionada ao contexto de autenticação
- Atualizado login para retornar dados do usuário

## Testes
- `npm test` falhou por falta de variáveis de ambiente durante execuções do Prisma

------
https://chatgpt.com/codex/tasks/task_e_684912f5796c8330a1fb7223839652b8