### PR TITLE
Corrige ícones dos botões inferiores

### DIFF
--- a/frontend/pages/admin/companies.tsx
+++ b/frontend/pages/admin/companies.tsx
@@ -219,28 +219,30 @@ export default function CompaniesPage() {
               />
 
               <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={closeForm}
-                  disabled={formLoading}
-                  className="flex items-center gap-2"
-                >
-                  Cancelar
-                </Button>
-                <Button
-                  variant="accent"
-                  onClick={handleSubmit}
-                  disabled={formLoading}
-                  className="flex items-center gap-2"
-                >
-                  {formLoading
-                    ? 'Salvando...'
-                    : editingCompany
-                      ? 'Salvar Alterações'
-                      : 'Criar Empresa'
-                  }
-                </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingCompany
+                    ? 'Salvar Alterações'
+                    : 'Criar Empresa'
+                }
+              </Button>
               </div>
             </div>
           </Card>

--- a/frontend/pages/admin/users.tsx
+++ b/frontend/pages/admin/users.tsx
@@ -487,28 +487,30 @@ export default function UsersPage() {
               )}
 
               <div className="flex justify-end gap-4 pt-6 border-t border-gray-700">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={closeForm}
-                  disabled={formLoading}
-                  className="flex items-center gap-2"
-                >
-                  Cancelar
-                </Button>
-                <Button
-                  variant="accent"
-                  onClick={handleSubmit}
-                  disabled={formLoading || (!editingUser && companies.length === 0)}
-                  className="flex items-center gap-2"
-                >
-                  {formLoading
-                    ? 'Salvando...'
-                    : editingUser
-                      ? 'Salvar Alterações'
-                      : 'Criar Usuário'
-                  }
-                </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeForm}
+                disabled={formLoading}
+                className="flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                variant="accent"
+                onClick={handleSubmit}
+                disabled={formLoading || (!editingUser && companies.length === 0)}
+                className="flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingUser
+                    ? 'Salvar Alterações'
+                    : 'Criar Usuário'
+                }
+              </Button>
               </div>
             </div>
           </Card>

--- a/frontend/pages/financial/accounts.tsx
+++ b/frontend/pages/financial/accounts.tsx
@@ -601,6 +601,7 @@ function AccountsPageInner() {
                 disabled={formLoading}
                 className="flex items-center gap-2"
               >
+                <X size={16} />
                 Cancelar
               </Button>
               <Button
@@ -609,6 +610,7 @@ function AccountsPageInner() {
                 disabled={formLoading}
                 className="flex items-center gap-2"
               >
+                <Save size={16} />
                 {formLoading
                   ? 'Salvando...'
                   : editingAccount
@@ -855,6 +857,7 @@ function AccountsPageInner() {
                 className="flex-1 flex items-center gap-2"
                 disabled={formLoading}
               >
+                <X size={16} />
                 Cancelar
               </Button>
               <Button
@@ -863,6 +866,7 @@ function AccountsPageInner() {
                 className="flex-1 flex items-center gap-2"
                 disabled={formLoading}
               >
+                <Save size={16} />
                 {formLoading ? 'Ajustando...' : 'Ajustar Saldo'}
               </Button>
             </div>

--- a/frontend/pages/financial/categories.tsx
+++ b/frontend/pages/financial/categories.tsx
@@ -419,6 +419,7 @@ function CategoriesPageInner() {
                 disabled={formLoading}
                 className="flex items-center gap-2"
               >
+                <X size={16} />
                 Cancelar
               </Button>
               <Button
@@ -427,6 +428,7 @@ function CategoriesPageInner() {
                 disabled={formLoading}
                 className="flex items-center gap-2"
               >
+                <Save size={16} />
                 {formLoading
                   ? 'Salvando...'
                   : editingCategory

--- a/frontend/pages/financial/recurring.tsx
+++ b/frontend/pages/financial/recurring.tsx
@@ -668,27 +668,29 @@ export default function FinancialRecurringPage() {
               </div>
               
               <div className="flex justify-end gap-4 mt-6 pt-6 border-t border-gray-700">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={resetForm}
-                  className="flex-1 flex items-center gap-2"
-                >
-                  Cancelar
-                </Button>
-                <Button
-                  type="submit"
-                  variant="accent"
-                  disabled={formLoading}
-                  className="flex-1 flex items-center gap-2"
-                >
-                  {formLoading
-                    ? 'Salvando...'
-                    : editingId
-                      ? 'Atualizar'
-                      : 'Criar'
-                  }
-                </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={resetForm}
+                className="flex-1 flex items-center gap-2"
+              >
+                <X size={16} />
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant="accent"
+                disabled={formLoading}
+                className="flex-1 flex items-center gap-2"
+              >
+                <Save size={16} />
+                {formLoading
+                  ? 'Salvando...'
+                  : editingId
+                    ? 'Atualizar'
+                    : 'Criar'
+                }
+              </Button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Resumo
- adiciona ícones de cancelar e salvar nos botões inferiores das telas de cadastro

## Testes
- `npm test` *(falha: variável de ambiente DATABASE_URL ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68496bb0a4dc83309788d43ebc631c1c