### PR TITLE
Implementação de workspace

### DIFF
--- a/backend/__tests__/company.test.ts
+++ b/backend/__tests__/company.test.ts
@@ -56,6 +56,7 @@ describe('Company routes (RBAC)', () => {
       const res = await request(app)
         .post('/api/companies')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString())
         .send({ name: 'Nova', address: 'Rua X' });
       expect(res.status).toBe(201);
       expect(res.body).toHaveProperty('id');
@@ -65,6 +66,7 @@ describe('Company routes (RBAC)', () => {
       const res = await request(app)
         .post('/api/companies')
         .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'Err', address: 'Rua Y' });
       expect(res.status).toBe(403);
     });
@@ -74,7 +76,8 @@ describe('Company routes (RBAC)', () => {
     it('ADMIN vê todas as empresas', async () => {
       const res = await request(app)
         .get('/api/companies')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString());
       expect(res.status).toBe(200);
       // Existem pelo menos Equinox e Outra
       expect(res.body.length).toBeGreaterThanOrEqual(2);
@@ -83,14 +86,16 @@ describe('Company routes (RBAC)', () => {
     it('SUPERUSER não pode listar', async () => {
       const res = await request(app)
         .get('/api/companies')
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
 
     it('USER não pode listar', async () => {
       const res = await request(app)
         .get('/api/companies')
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
   });
@@ -100,6 +105,7 @@ describe('Company routes (RBAC)', () => {
       const res = await request(app)
         .put(`/api/companies/${equinoxId}`)
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString())
         .send({ name: 'EquinoxX' });
       expect(res.status).toBe(200);
       expect(res.body.name).toBe('EquinoxX');
@@ -109,6 +115,7 @@ describe('Company routes (RBAC)', () => {
       const res = await request(app)
         .put(`/api/companies/${otherCompanyId}`)
         .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'Teste' });
       expect(res.status).toBe(403);
     });
@@ -119,14 +126,16 @@ describe('Company routes (RBAC)', () => {
       const nova = await prisma.company.create({ data: { name: 'Temp', code: 99 } });
       const res = await request(app)
         .delete(`/api/companies/${nova.id}`)
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString());
       expect(res.status).toBe(204);
     });
 
     it('USER não pode excluir', async () => {
       const res = await request(app)
         .delete(`/api/companies/${equinoxId}`)
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
   });

--- a/backend/__tests__/financial.tests.ts
+++ b/backend/__tests__/financial.tests.ts
@@ -95,6 +95,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/accounts')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           name: 'Conta Corrente',
           type: 'CHECKING',
@@ -114,6 +115,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/accounts')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           name: 'Poupança',
           type: 'SAVINGS',
@@ -132,7 +134,8 @@ describe('Módulo Financeiro', () => {
     it('Deve listar as contas criadas', async () => {
       const res = await request(app)
         .get('/api/financial/accounts')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString());
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
@@ -175,6 +178,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/categories')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           name: 'Alimentação',
           type: 'EXPENSE',
@@ -193,6 +197,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/categories')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           name: 'Salário',
           type: 'INCOME',
@@ -210,7 +215,8 @@ describe('Módulo Financeiro', () => {
     it('Deve listar as categorias criadas', async () => {
       const res = await request(app)
         .get('/api/financial/categories')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString());
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
@@ -223,6 +229,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/transactions')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           description: 'Compra Supermercado',
           amount: 150.75,
@@ -254,6 +261,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/transactions')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           description: 'Salário Mensal',
           amount: 3000,
@@ -286,6 +294,7 @@ describe('Módulo Financeiro', () => {
       const res = await request(app)
         .post('/api/financial/transactions')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           description: 'Transferência para Poupança',
           amount: 500,
@@ -328,6 +337,7 @@ describe('Módulo Financeiro', () => {
       const createRes = await request(app)
         .post('/api/financial/transactions')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           description: 'Compra para Cancelar',
           amount: 200,
@@ -353,6 +363,7 @@ describe('Módulo Financeiro', () => {
       const updateRes = await request(app)
         .patch(`/api/financial/transactions/${transactionId}/status`)
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString())
         .send({
           status: 'CANCELED'
         });
@@ -372,7 +383,8 @@ describe('Módulo Financeiro', () => {
     it('Deve obter um resumo financeiro', async () => {
       const res = await request(app)
         .get('/api/financial/summary')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', companyId.toString());
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('income');
@@ -390,7 +402,8 @@ describe('Módulo Financeiro', () => {
     it('Usuário comum vê apenas contas permitidas no resumo', async () => {
       const res = await request(app)
         .get('/api/financial/summary')
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', companyId.toString());
 
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body.accounts)).toBe(true);

--- a/backend/__tests__/user.test.ts
+++ b/backend/__tests__/user.test.ts
@@ -77,7 +77,8 @@ describe('User routes (CRUD & RBAC)', () => {
     it('ADMIN vê todos os usuários', async () => {
       const res = await request(app)
         .get('/api/users')
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString());
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(3);
     });
@@ -85,7 +86,8 @@ describe('User routes (CRUD & RBAC)', () => {
     it('SUPERUSER vê só usuários da sua empresa', async () => {
       const res = await request(app)
         .get('/api/users')
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(200);
       expect(res.body.map((u: any) => u.email).sort()).toEqual(
         ['super@outra.com', 'user@outra.com'].sort()
@@ -95,7 +97,8 @@ describe('User routes (CRUD & RBAC)', () => {
     it('USER vê apenas seu próprio registro', async () => {
       const res = await request(app)
         .get('/api/users')
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
       expect(res.body[0].email).toBe('user@outra.com');
@@ -107,6 +110,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .post('/api/users')
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString())
         .send({
           email: 'novo@outra.com',
           password: '1234',
@@ -122,6 +126,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .post('/api/users')
         .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({
           email: 'x@equinox.com',
           password: '1234',
@@ -136,6 +141,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .post('/api/users')
         .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({
           email: 'y@outra.com',
           password: '1234',
@@ -151,7 +157,8 @@ describe('User routes (CRUD & RBAC)', () => {
     it('ADMIN pode ver qualquer usuário pelo ID', async () => {
       const res = await request(app)
         .get(`/api/users/${userId}`)
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString());
       expect(res.status).toBe(200);
       expect(res.body.email).toBe('user@outra.com');
     });
@@ -159,26 +166,30 @@ describe('User routes (CRUD & RBAC)', () => {
     it('SUPERUSER pode ver usuários da sua empresa', async () => {
       const res = await request(app)
         .get(`/api/users/${userId}`)
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(200);
     });
 
     it('SUPERUSER não pode ver usuários de outra empresa', async () => {
       const res = await request(app)
         .get(`/api/users/${adminId}`)
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
 
     it('USER só pode ver seu próprio perfil', async () => {
       const resOk = await request(app)
         .get(`/api/users/${userId}`)
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(resOk.status).toBe(200);
 
       const resNo = await request(app)
         .get(`/api/users/${superId}`)
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(resNo.status).toBe(403);
     });
   });
@@ -188,6 +199,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .put(`/api/users/${userId}`)
         .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString())
         .send({ name: 'User Edited By Admin' });
       expect(res.status).toBe(200);
       expect(res.body.name).toBe('User Edited By Admin');
@@ -197,6 +209,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .put(`/api/users/${superId}`)
         .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'Super Edited' });
       expect(res.status).toBe(200);
       expect(res.body.name).toBe('Super Edited');
@@ -206,6 +219,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const res = await request(app)
         .put(`/api/users/${adminId}`)
         .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'Should Fail' });
       expect(res.status).toBe(403);
     });
@@ -214,6 +228,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const resOk = await request(app)
         .put(`/api/users/${userId}`)
         .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'User Self-Edited' });
       expect(resOk.status).toBe(200);
       expect(resOk.body.name).toBe('User Self-Edited');
@@ -221,6 +236,7 @@ describe('User routes (CRUD & RBAC)', () => {
       const resNo = await request(app)
         .put(`/api/users/${superId}`)
         .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString())
         .send({ name: 'Attempt Fail' });
       expect(resNo.status).toBe(403);
     });
@@ -236,7 +252,8 @@ describe('User routes (CRUD & RBAC)', () => {
       });
       const res = await request(app)
         .delete(`/api/users/${temp.id}`)
-        .set('Authorization', `Bearer ${adminToken}`);
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('X-Company-Id', equinoxId.toString());
       expect(res.status).toBe(204);
     });
 
@@ -249,21 +266,24 @@ describe('User routes (CRUD & RBAC)', () => {
       });
       const res = await request(app)
         .delete(`/api/users/${temp2.id}`)
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(204);
     });
 
     it('SUPERUSER não pode excluir usuário de outra empresa', async () => {
       const res = await request(app)
         .delete(`/api/users/${adminId}`)
-        .set('Authorization', `Bearer ${superToken}`);
+        .set('Authorization', `Bearer ${superToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
 
     it('USER não pode excluir usuários', async () => {
       const res = await request(app)
         .delete(`/api/users/${superId}`)
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('X-Company-Id', otherCompanyId.toString());
       expect(res.status).toBe(403);
     });
   });

--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -4,7 +4,7 @@ declare global {
   namespace Express {
     interface Request {
       user: (Partial<User> & {
-        companyId: number;
+        companyId?: number;
       }) & {
         /**
          * When authenticated via JWT the middleware attaches the

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -108,10 +108,9 @@ export async function login(req: Request, res: Response) {
     const companyName = userCompany.company.name;
 
     // Gerar tokens
-    const tokenPayload = { 
-      userId: user.id, 
-      companyId, 
-      role: user.role 
+    const tokenPayload = {
+      userId: user.id,
+      role: user.role
     };
     
     const token = generateToken(tokenPayload);
@@ -193,10 +192,9 @@ export async function refreshToken(req: Request, res: Response) {
     }
 
     // Gerar novo access token
-    const newToken = generateToken({ 
-      userId: user.id, 
-      companyId: decoded.companyId, 
-      role: user.role 
+    const newToken = generateToken({
+      userId: user.id,
+      role: user.role
     });
     
     logger.info('Token refreshed successfully', {

--- a/backend/src/middlewares/tenant.middleware.ts
+++ b/backend/src/middlewares/tenant.middleware.ts
@@ -1,18 +1,38 @@
-import { User } from '@prisma/client';
 import { Request, Response, NextFunction } from 'express';
+import UserService from '../services/user.service';
 
 /**
  * Middleware para garantir que a requisição tem uma empresa definida
  * Versão simplificada: verifica apenas que há um companyId no token
  */
-export function tenantMiddleware(
+export async function tenantMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
-): void {
-  if (!req.user || !req.user.companyId) {
-    res.status(403).json({ error: 'Acesso não autorizado: empresa não definida' });
+): Promise<void> {
+  try {
+    const header = req.headers['x-company-id'];
+    const companyId = header ? parseInt(Array.isArray(header) ? header[0] : header) : NaN;
+
+  if (!header || isNaN(companyId)) {
+    res.status(403).json({ error: 'Empresa não informada ou inválida' });
     return;
   }
-  next();
+
+  if (!req.user || !req.user.userId) {
+    res.status(403).json({ error: 'Usuário não autenticado' });
+    return;
+  }
+
+    const belongs = await UserService.userBelongsToCompany(req.user.userId, companyId);
+    if (!belongs) {
+      res.status(403).json({ error: 'Acesso não autorizado à empresa' });
+      return;
+    }
+
+    req.user.companyId = companyId;
+    next();
+  } catch (error) {
+    res.status(500).json({ error: 'Erro ao validar empresa' });
+  }
 }

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -7,7 +7,6 @@ import { JWT_SECRET } from '../config';
  */
 export function generateToken(payload: {
   userId: number;
-  companyId: number;  // Agora apenas um ID de empresa, não um array
   role: string;
 }): string {
   return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
@@ -18,7 +17,6 @@ export function generateToken(payload: {
  */
 export function generateRefreshToken(payload: {
   userId: number;
-  companyId: number;
   role: string;
 }): string {
   const { password, ...payloadWithoutSensitiveData } = payload as any;

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -96,6 +96,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [companyId, setCompanyId] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [mustChangePassword, setMustChangePassword] = useState<boolean>(false);
 
@@ -123,6 +124,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         setToken(storedToken);
         setUser({ ...response.data.user, mustChangePassword: storedMustChange === 'true' });
+
+        const storedCompanyId = localStorage.getItem('zenit_company_id');
+        const initialCompanyId = storedCompanyId
+          ? Number(storedCompanyId)
+          : response.data.user.company?.id || null;
+        setCompanyId(initialCompanyId);
+        if (!storedCompanyId && initialCompanyId !== null) {
+          localStorage.setItem('zenit_company_id', String(initialCompanyId));
+        }
       }
     } catch (error) {
       console.error('Erro ao inicializar autenticação:', error);
@@ -160,6 +170,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       setToken(newToken);
       setUser(userData);
+      if (userData.company?.id) {
+        setCompanyId(userData.company.id);
+        localStorage.setItem('zenit_company_id', userData.company.id.toString());
+      }
 
       return userData;
       
@@ -218,12 +232,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('zenit_token');
     localStorage.removeItem('zenit_refresh_token');
     localStorage.removeItem('zenit_must_change_password');
+    localStorage.removeItem('zenit_company_id');
     
     // Remover APENAS nosso cookie específico
     removeSecureCookie('zenit_token');
     
     setToken(null);
     setUser(null);
+    setCompanyId(null);
   }
 
   function logout() {
@@ -283,7 +299,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isLoading,
         userRole: user?.role || null,
         userId: user?.id || null,
-        companyId: user?.company?.id || null,
+        companyId,
         userName: user?.name || null,
         companyName: user?.company?.name || null,
         manageFinancialAccounts: user?.manageFinancialAccounts || false,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -24,6 +24,10 @@ api.interceptors.request.use(config => {
   if (token && config.headers) {
     config.headers.Authorization = `Bearer ${token}`
   }
+  const companyId = localStorage.getItem('zenit_company_id')
+  if (companyId && config.headers) {
+    config.headers['X-Company-Id'] = companyId
+  }
   return config
 });
 
@@ -46,3 +50,4 @@ api.interceptors.response.use(
 );
 
 export default api
+


### PR DESCRIPTION
## Resumo
- remover `companyId` dos tokens JWT
- validar cabeçalho `X-Company-Id` no middleware de tenant
- ajustar AuthContext para armazenar empresa ativa
- enviar cabeçalho `X-Company-Id` no cliente HTTP
- atualizar testes

## Testes
- `npm run lint` *(falha: ESLint configuration missing)*
- `npm test` *(falha: DATABASE_URL ausente para Prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68496d345f0c833089e3054e1363bdd7