### PR TITLE
Integração inicial do app com backend Zenit

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   financialAccountAccess UserFinancialAccountAccess[]
   grantedPermissions     UserFinancialAccountAccess[] @relation("GrantedPermissions")
   preference             UserPreference?
+  budgets               Budget[]
 }
 
 model Company {
@@ -74,6 +75,7 @@ model Company {
   financialTags       FinancialTag[]
   recurringTransactions RecurringTransaction[]
   userFinancialAccountAccess UserFinancialAccountAccess[]
+  budgets             Budget[]
 }
 
 model CompanyGroup {
@@ -174,6 +176,8 @@ model FinancialTransaction {
   toAccount       FinancialAccount?    @relation("ToAccount", fields: [toAccountId], references: [id])
   categoryId      Int?
   category        FinancialCategory?   @relation(fields: [categoryId], references: [id])
+  budgetId        Int?
+  budget          Budget?              @relation(fields: [budgetId], references: [id])
   companyId       Int
   company         Company              @relation(fields: [companyId], references: [id], onDelete: Cascade)
   createdBy       Int
@@ -191,6 +195,7 @@ model FinancialTransaction {
   @@index([toAccountId])
   @@index([categoryId])
   @@index([date])
+  @@index([budgetId])
   
   // ✅ NOVOS ÍNDICES PARA PERFORMANCE
   @@index([dueDate, status])                              // Relatórios de inadimplência
@@ -274,4 +279,43 @@ model UserPreference {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+enum BudgetStatus {
+  ACTIVE
+  ARCHIVED
+  EXPIRED
+  DELETED
+}
+
+enum BudgetType {
+  SPENDING
+  SAVING
+}
+
+model Budget {
+  id                Int       @id @default(autoincrement())
+  code              String    @unique
+  initialAmount     Decimal   @db.Decimal(15, 2)
+  currentBalance    Decimal   @db.Decimal(15, 2)
+  endDate           DateTime
+  desiredFinalBalance Decimal @db.Decimal(15, 2)
+  dailyBudgetInitial Decimal  @db.Decimal(15, 2)
+  dailyBudgetCurrent Decimal  @db.Decimal(15, 2)
+  startDate         DateTime
+  type              BudgetType
+  dailyBudgetDate   DateTime
+  isWork            Boolean   @default(false)
+  status            BudgetStatus @default(ACTIVE)
+  extraDailyBalance Decimal   @db.Decimal(15, 2) @default(0)
+  companyId         Int
+  company           Company   @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  createdBy         Int
+  createdByUser     User      @relation(fields: [createdBy], references: [id])
+  transactions      FinancialTransaction[]
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  @@index([companyId])
+  @@index([code])
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import userRoutes from './routes/user.routes';
 import companyRoutes from './routes/company.routes';
 import financialRoutes from './routes/financial.routes';
 import preferenceRoutes from './routes/preferences.routes';
+import budgetRoutes from './routes/budget.routes';
 
 import { authMiddleware } from './middlewares/auth.middleware';
 import { tenantMiddleware } from './middlewares/tenant.middleware';
@@ -170,6 +171,7 @@ app.use('/api', tenantMiddleware);
 app.use('/api/users', createRateLimitMiddleware('api'), userRoutes);
 app.use('/api/companies', createRateLimitMiddleware('api'), companyRoutes);
 app.use('/api/preferences', createRateLimitMiddleware('api'), preferenceRoutes);
+app.use('/api/mobile', createRateLimitMiddleware('api'), budgetRoutes);
 app.use('/api/financial', createRateLimitMiddleware('financial'), financialRoutes);
 // Financial routes with cache for read operations
 app.use('/api/financial/summary', createRateLimitMiddleware('financial'), cacheMiddleware(600)); // 10min cache

--- a/backend/src/controllers/budget.controller.ts
+++ b/backend/src/controllers/budget.controller.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from 'express';
+import BudgetService from '../services/budget.service';
+import { BudgetStatus, BudgetType, TransactionType } from '@prisma/client';
+
+function getContext(req: Request) {
+  const { companyId, userId } = req.user as any;
+  return { companyId: Number(companyId), userId: Number(userId) };
+}
+
+export async function createOrUpdateBudget(req: Request, res: Response) {
+  try {
+    const { companyId, userId } = getContext(req);
+    const budget = await BudgetService.createOrUpdateBudget({
+      ...req.body,
+      companyId,
+      createdBy: userId
+    });
+    res.status(201).json(budget);
+  } catch (error: any) {
+    res.status(400).json({ error: error.message });
+  }
+}
+
+export async function listBudgets(req: Request, res: Response) {
+  try {
+    const { companyId } = getContext(req);
+    const budgets = await BudgetService.listBudgets(companyId);
+    res.json(budgets);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+export async function addTransaction(req: Request, res: Response) {
+  try {
+    const { companyId, userId } = getContext(req);
+    const { id } = req.params;
+    const tx = await BudgetService.addTransaction(Number(id), {
+      ...req.body,
+      companyId,
+      createdBy: userId,
+      type: req.body.type as TransactionType
+    });
+    res.status(201).json(tx);
+  } catch (error: any) {
+    res.status(400).json({ error: error.message });
+  }
+}
+

--- a/backend/src/routes/budget.routes.ts
+++ b/backend/src/routes/budget.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { createOrUpdateBudget, listBudgets, addTransaction } from '../controllers/budget.controller';
+import { validate } from '../middlewares/validate.middleware';
+
+const router = Router();
+
+router.get('/budgets', listBudgets);
+router.post('/budgets', createOrUpdateBudget);
+router.post('/budgets/:id/transactions', addTransaction);
+
+export default router;
+

--- a/backend/src/services/budget.service.ts
+++ b/backend/src/services/budget.service.ts
@@ -1,0 +1,122 @@
+import { PrismaClient, Budget, BudgetStatus, BudgetType, TransactionType } from '@prisma/client';
+import FinancialTransactionService from './financial-transaction.service';
+import DefaultService from './default.service';
+
+const prisma = new PrismaClient();
+
+export default class BudgetService {
+  static async createOrUpdateBudget(data: {
+    id?: number;
+    code: string;
+    initialAmount: number | string;
+    currentBalance: number | string;
+    endDate: Date;
+    desiredFinalBalance: number | string;
+    dailyBudgetInitial: number | string;
+    dailyBudgetCurrent: number | string;
+    startDate: Date;
+    type: BudgetType;
+    dailyBudgetDate: Date;
+    isWork?: boolean;
+    status?: BudgetStatus;
+    extraDailyBalance?: number | string;
+    companyId: number;
+    createdBy: number;
+  }): Promise<Budget> {
+    const {
+      id,
+      code,
+      initialAmount,
+      currentBalance,
+      endDate,
+      desiredFinalBalance,
+      dailyBudgetInitial,
+      dailyBudgetCurrent,
+      startDate,
+      type,
+      dailyBudgetDate,
+      isWork = false,
+      status = BudgetStatus.ACTIVE,
+      extraDailyBalance = 0,
+      companyId,
+      createdBy
+    } = data;
+
+    if (id) {
+      return prisma.budget.update({
+        where: { id },
+        data: {
+          code,
+          initialAmount,
+          currentBalance,
+          endDate,
+          desiredFinalBalance,
+          dailyBudgetInitial,
+          dailyBudgetCurrent,
+          startDate,
+          type,
+          dailyBudgetDate,
+          isWork,
+          status,
+          extraDailyBalance,
+          companyId,
+          createdBy
+        }
+      });
+    }
+
+    return prisma.budget.create({
+      data: {
+        code,
+        initialAmount,
+        currentBalance,
+        endDate,
+        desiredFinalBalance,
+        dailyBudgetInitial,
+        dailyBudgetCurrent,
+        startDate,
+        type,
+        dailyBudgetDate,
+        isWork,
+        status,
+        extraDailyBalance,
+        companyId,
+        createdBy
+      }
+    });
+  }
+
+  static async listBudgets(companyId: number): Promise<Budget[]> {
+    return prisma.budget.findMany({
+      where: { companyId }
+    });
+  }
+
+  static async addTransaction(budgetId: number, params: {
+    description: string;
+    amount: number | string;
+    date: Date;
+    type: TransactionType;
+    companyId: number;
+    createdBy: number;
+  }) {
+    const { companyId, createdBy, ...data } = params;
+    const defaults = await DefaultService.getCompanyDefaults(companyId);
+    const category =
+      data.type === TransactionType.EXPENSE
+        ? defaults.categories.expense
+        : defaults.categories.income;
+
+    return FinancialTransactionService.createTransaction({
+      ...data,
+      budgetId,
+      status: 'COMPLETED',
+      fromAccountId: defaults.account?.id,
+      toAccountId: defaults.account?.id,
+      categoryId: category?.id,
+      companyId,
+      createdBy
+    });
+  }
+}
+

--- a/backend/src/services/financial-transaction.service.ts
+++ b/backend/src/services/financial-transaction.service.ts
@@ -27,6 +27,7 @@ export default class FinancialTransactionService {
     fromAccountId?: number | null;
     toAccountId?: number | null;
     categoryId?: number | null;
+    budgetId?: number | null;
     companyId: number;
     createdBy: number;
     tags?: string[];
@@ -172,6 +173,7 @@ export default class FinancialTransactionService {
           fromAccount: data.fromAccountId ? { connect: { id: data.fromAccountId } } : undefined,
           toAccount: data.toAccountId ? { connect: { id: data.toAccountId } } : undefined,
           category: data.categoryId ? { connect: { id: data.categoryId } } : undefined,
+          budget: data.budgetId ? { connect: { id: data.budgetId } } : undefined,
           company: { connect: { id: data.companyId } },
           createdByUser: { connect: { id: data.createdBy } },
           tags: data.tags && data.tags.length > 0 ? {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:orcamento_app/pages/lista_orcamentos_inativos_page.dart';
@@ -14,17 +13,8 @@ import 'pages/login_page.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'utils.dart';
 
-// Importa as opções do Firebase para cada plataforma.
-// O arquivo firebase_options.dart é gerado pelo FlutterFire CLI (ou você pode criá-lo manualmente)
-import 'firebase_options.dart';
-
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  // Inicializa o Firebase com as opções adequadas para cada plataforma:
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
 
   await Hive.initFlutter();
   Hive.registerAdapter(OrcamentoAdapter());

--- a/mobile/lib/pages/entry_point.dart
+++ b/mobile/lib/pages/entry_point.dart
@@ -6,8 +6,7 @@ import '../models/orcamento.dart';
 import 'lista_orcamentos_page.dart';
 import 'resumo_orcamento_page.dart';
 import '../utils.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/api_service.dart';
 import 'package:orcamento_app/services/sync_manager.dart';
 
 class EntryPoint extends StatefulWidget {
@@ -55,26 +54,10 @@ class _EntryPointState extends State<EntryPoint> {
   }
 
   void _startSyncIfNeeded() {
-    // Importa o FirebaseAuth e FirebaseFirestore
-    // Certifique-se de ter adicionado a dependência firebase_auth no pubspec.yaml
-    // e também que o arquivo sync_manager.dart está disponível em lib/services/
-    //
-    // Esse código assume que você importou:
-    // import 'package:firebase_auth/firebase_auth.dart';
-    // import 'package:cloud_firestore/cloud_firestore.dart';
-    // import 'package:orcamento_app/services/sync_manager.dart';
-    final user = FirebaseAuth.instance.currentUser;
-    if (user != null) {
-      // Instancia o SyncManager passando o box local e a instância do Firestore
-      final syncManager = SyncManager(
-        localBox: box,
-        firestore: FirebaseFirestore.instance,
-      );
-      // Inicia a escuta das alterações (push)
-      syncManager.startListening();
-      // Realiza um pull inicial dos dados do backend
-      syncManager.pullOrcamentos();
-    }
+    final api = ApiService();
+    final syncManager = SyncManager(localBox: box, api: api);
+    syncManager.startListening();
+    syncManager.pullOrcamentos();
   }
 
   @override

--- a/mobile/lib/pages/login_page.dart
+++ b/mobile/lib/pages/login_page.dart
@@ -1,6 +1,6 @@
 // lib/pages/login_page.dart
 
-import 'package:firebase_auth/firebase_auth.dart';
+import '../services/api_service.dart';
 import 'package:flutter/material.dart';
 
 class LoginPage extends StatefulWidget {
@@ -14,9 +14,8 @@ class _LoginPageState extends State<LoginPage> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  bool _isLoginMode = true; // true = login, false = cadastro
   String? _error;
-  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final ApiService api = ApiService();
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
@@ -24,22 +23,14 @@ class _LoginPageState extends State<LoginPage> {
       _error = null;
     });
     try {
-      if (_isLoginMode) {
-        await _auth.signInWithEmailAndPassword(
-          email: _emailController.text.trim(),
-          password: _passwordController.text.trim(),
-        );
-      } else {
-        await _auth.createUserWithEmailAndPassword(
-          email: _emailController.text.trim(),
-          password: _passwordController.text.trim(),
-        );
-      }
-      // Depois de autenticar, retorne à tela principal (por exemplo, a listagem)
+      await api.login(
+        _emailController.text.trim(),
+        _passwordController.text.trim(),
+      );
       Navigator.pop(context);
-    } on FirebaseAuthException catch (e) {
+    } catch (e) {
       setState(() {
-        _error = e.message;
+        _error = e.toString();
       });
     }
   }
@@ -48,7 +39,7 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(_isLoginMode ? 'Entrar' : 'Criar Conta'),
+        title: const Text('Entrar'),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -84,17 +75,7 @@ class _LoginPageState extends State<LoginPage> {
               const SizedBox(height: 20),
               ElevatedButton(
                 onPressed: _submit,
-                child: Text(_isLoginMode ? 'Entrar' : 'Registrar'),
-              ),
-              TextButton(
-                onPressed: () {
-                  setState(() {
-                    _isLoginMode = !_isLoginMode;
-                  });
-                },
-                child: Text(_isLoginMode
-                    ? 'Criar nova conta'
-                    : 'Já possui conta? Entrar'),
+                child: const Text('Entrar'),
               ),
             ],
           ),

--- a/mobile/lib/services/api_service.dart
+++ b/mobile/lib/services/api_service.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class ApiService {
+  final String baseUrl = dotenv.env['API_URL'] ?? 'http://localhost:3000';
+  String? token;
+
+  Future<void> login(String email, String password) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/auth/login'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'email': email, 'password': password}),
+    );
+    if (response.statusCode == 201 || response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      token = data['token'];
+    } else {
+      throw Exception('Falha no login');
+    }
+  }
+
+  Map<String, String> authHeaders() {
+    return {
+      'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'Bearer $token'
+    };
+  }
+
+  Future<void> post(String path, Map<String, dynamic> data) async {
+    await http.post(
+      Uri.parse(baseUrl + path),
+      headers: authHeaders(),
+      body: jsonEncode(data),
+    );
+  }
+
+  Future<List<dynamic>> getList(String path) async {
+    final response = await http.get(
+      Uri.parse(baseUrl + path),
+      headers: authHeaders(),
+    );
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as List<dynamic>;
+    }
+    throw Exception('Erro na requisição');
+  }
+}

--- a/mobile/lib/widgets/app_drawer.dart
+++ b/mobile/lib/widgets/app_drawer.dart
@@ -1,7 +1,6 @@
 // lib/widgets/app_drawer.dart
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 
 class AppDrawer extends StatelessWidget {
@@ -14,10 +13,8 @@ class AppDrawer extends StatelessWidget {
   }
 
   Widget _buildSyncSection(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
-    bool isLoggedIn = user != null;
     DateTime? lastSync = getLastSync();
-    if (isLoggedIn) {
+    if (true) {
       if (lastSync != null) {
         return ListTile(
           leading: const Icon(Icons.sync),
@@ -36,16 +33,6 @@ class AppDrawer extends StatelessWidget {
           onTap: () {},
         );
       }
-    } else {
-      return ListTile(
-        leading: const Icon(Icons.sync_disabled),
-        title: const Text("Sincronização"),
-        subtitle: const Text("Faça login para sincronizar"),
-        onTap: () {
-          Navigator.pushNamed(context, '/login');
-        },
-      );
-    }
   }
 
   @override

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -15,9 +15,7 @@ dependencies:
   path_provider: ^2.1.2
   intl: ^0.18.1
   flutter_speed_dial: ^6.1.0
-  firebase_core: ^3.13.0
-  firebase_auth: ^5.5.2
-  cloud_firestore: ^5.6.6
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Resumo
- criar entidade **Budget** e relacionamentos
- permitir associar transações a budgets
- criar serviços e rotas para budgets
- remover Firebase do app Flutter e adicionar serviço HTTP
- ajustar telas de login, entry point e drawer
- sincronização agora usa API do backend

## Testes
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68646d49f4408330a62a0cf89e8eb823