### PR TITLE
Ajusta confirmações de saldo negativo e preferências do usuário

### DIFF
--- a/backend/prisma/migrations/20250715093000_add_negative_balance_confirmation_preference/migration.sql
+++ b/backend/prisma/migrations/20250715093000_add_negative_balance_confirmation_preference/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "UserPreference"
+ADD COLUMN "confirmNegativeBalanceMovements" BOOLEAN NOT NULL DEFAULT true;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -275,6 +275,7 @@ model UserPreference {
   id Int @id @default(autoincrement())
   userId Int @unique
   colorScheme String?
+  confirmNegativeBalanceMovements Boolean @default(true)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -141,7 +141,8 @@ export async function login(req: Request, res: Response) {
         companies
       },
       preferences: {
-        colorScheme: preferences?.colorScheme || null
+        colorScheme: preferences?.colorScheme || null,
+        confirmNegativeBalanceMovements: preferences?.confirmNegativeBalanceMovements ?? true
       },
       message: 'Login realizado com sucesso'
     });
@@ -268,7 +269,8 @@ export async function getCurrentUser(req: Request, res: Response) {
         companies
       },
       preferences: {
-        colorScheme: preferences?.colorScheme || null
+        colorScheme: preferences?.colorScheme || null,
+        confirmNegativeBalanceMovements: preferences?.confirmNegativeBalanceMovements ?? true
       }
     });
 

--- a/backend/src/controllers/user-preference.controller.ts
+++ b/backend/src/controllers/user-preference.controller.ts
@@ -1,11 +1,18 @@
 import { Request, Response } from 'express';
-import { getUserPreference, setColorScheme } from '../services/user-preference.service';
+import { getUserPreference, setColorScheme, updateUserPreferences } from '../services/user-preference.service';
+
+function formatPreference(preference: any) {
+  return {
+    colorScheme: preference?.colorScheme ?? null,
+    confirmNegativeBalanceMovements: preference?.confirmNegativeBalanceMovements ?? true
+  };
+}
 
 export async function getPreferences(req: Request, res: Response) {
   // @ts-ignore
   const userId = req.user.userId as number;
   const pref = await getUserPreference(userId);
-  res.json(pref || {});
+  res.json(formatPreference(pref));
 }
 
 export async function updateColorScheme(req: Request, res: Response) {
@@ -16,5 +23,18 @@ export async function updateColorScheme(req: Request, res: Response) {
   // @ts-ignore
   const userId = req.user.userId as number;
   const pref = await setColorScheme(userId, colorScheme);
-  res.json(pref);
+  res.json(formatPreference(pref));
+}
+
+export async function updatePreferences(req: Request, res: Response) {
+  // @ts-ignore
+  const userId = req.user.userId as number;
+  const { colorScheme, confirmNegativeBalanceMovements } = req.body;
+
+  const pref = await updateUserPreferences(userId, {
+    colorScheme,
+    confirmNegativeBalanceMovements
+  });
+
+  res.json(formatPreference(pref));
 }

--- a/backend/src/routes/preferences.routes.ts
+++ b/backend/src/routes/preferences.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { validate } from '../middlewares/validate.middleware';
-import { getPreferences, updateColorScheme } from '../controllers/user-preference.controller';
-import { updateColorSchemeSchema } from '../validators/user-preference.validator';
+import { getPreferences, updateColorScheme, updatePreferences } from '../controllers/user-preference.controller';
+import { updateColorSchemeSchema, updatePreferencesSchema } from '../validators/user-preference.validator';
 
 const router = Router();
 
 router.get('/', getPreferences);
 router.put('/color-scheme', validate(updateColorSchemeSchema), updateColorScheme);
+router.put('/', validate(updatePreferencesSchema), updatePreferences);
 
 export default router;

--- a/backend/src/services/financial-structure.service.ts
+++ b/backend/src/services/financial-structure.service.ts
@@ -70,7 +70,8 @@ export default class FinancialStructureService {
             balance: 0,
             isActive: true,
             isDefault: true,
-            companyId
+            companyId,
+            allowNegativeBalance: true
           }
         });
         logger.info('Created default financial account', { 

--- a/backend/src/services/user-preference.service.ts
+++ b/backend/src/services/user-preference.service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -7,9 +7,33 @@ export async function getUserPreference(userId: number) {
 }
 
 export async function setColorScheme(userId: number, colorScheme: string) {
+  return updateUserPreferences(userId, { colorScheme });
+}
+
+export async function updateUserPreferences(
+  userId: number,
+  data: {
+    colorScheme?: string | null;
+    confirmNegativeBalanceMovements?: boolean;
+  }
+) {
+  const updateData: Prisma.UserPreferenceUpdateInput = {};
+
+  if (data.colorScheme !== undefined) {
+    updateData.colorScheme = data.colorScheme;
+  }
+
+  if (data.confirmNegativeBalanceMovements !== undefined) {
+    updateData.confirmNegativeBalanceMovements = data.confirmNegativeBalanceMovements;
+  }
+
   return prisma.userPreference.upsert({
     where: { userId },
-    update: { colorScheme },
-    create: { userId, colorScheme }
+    update: updateData,
+    create: {
+      userId,
+      colorScheme: data.colorScheme ?? null,
+      confirmNegativeBalanceMovements: data.confirmNegativeBalanceMovements ?? true
+    }
   });
 }

--- a/backend/src/validators/user-preference.validator.ts
+++ b/backend/src/validators/user-preference.validator.ts
@@ -3,3 +3,13 @@ import { z } from 'zod';
 export const updateColorSchemeSchema = z.object({
   colorScheme: z.string().min(1, { message: 'colorScheme é obrigatório.' })
 });
+
+export const updatePreferencesSchema = z.object({
+  colorScheme: z.string().min(1, { message: 'colorScheme é obrigatório.' }).optional(),
+  confirmNegativeBalanceMovements: z.boolean().optional()
+}).refine(
+  (data) => data.colorScheme !== undefined || data.confirmNegativeBalanceMovements !== undefined,
+  {
+    message: 'É necessário informar pelo menos uma preferência para atualizar.'
+  }
+);

--- a/frontend/components/ui/ConfirmationModal.tsx
+++ b/frontend/components/ui/ConfirmationModal.tsx
@@ -1,5 +1,5 @@
 // frontend/components/ui/ConfirmationModal.tsx
-import React, { useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import { Button } from './Button';
 
@@ -13,6 +13,7 @@ interface ConfirmationModalProps {
   cancelText?: string;
   type?: 'danger' | 'warning' | 'info';
   loading?: boolean;
+  children?: ReactNode;
 }
 
 export function ConfirmationModal({
@@ -24,7 +25,8 @@ export function ConfirmationModal({
   confirmText = 'Confirmar',
   cancelText = 'Cancelar',
   type = 'danger',
-  loading = false
+  loading = false,
+  children
 }: ConfirmationModalProps) {
   // Handle ESC key
   useEffect(() => {
@@ -106,6 +108,11 @@ export function ConfirmationModal({
               <p className="text-gray-300 leading-relaxed">
                 {message}
               </p>
+              {children && (
+                <div className="mt-4 text-gray-200">
+                  {children}
+                </div>
+              )}
             </div>
 
             {/* Actions */}

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,5 +1,5 @@
 // frontend/pages/profile.tsx
-import { useState } from 'react'
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { DashboardLayout } from '@/components/layout/DashboardLayout'
 import { Card } from '@/components/ui/Card'
@@ -7,25 +7,32 @@ import { Input } from '@/components/ui/Input'
 import { Button } from '@/components/ui/Button'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import { useToast } from '@/components/ui/ToastContext'
+import { getApiErrorMessage } from '@/utils/errors'
 
 export default function ProfilePage() {
-  const { user } = useAuth()
+  const { user, preferences, updatePreferences } = useAuth()
   const { addToast } = useToast()
-  
+
   const [formData, setFormData] = useState({
     name: user?.name || '',
     email: user?.email || '',
     password: '',
   })
-  
-  const [loading, setLoading] = useState(false)
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const [loading, setLoading] = useState(false)
+  const [confirmNegative, setConfirmNegative] = useState(preferences.confirmNegativeBalanceMovements)
+  const [preferencesLoading, setPreferencesLoading] = useState(false)
+
+  useEffect(() => {
+    setConfirmNegative(preferences.confirmNegativeBalanceMovements)
+  }, [preferences.confirmNegativeBalanceMovements])
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setFormData(prev => ({ ...prev, [name]: value }))
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setLoading(true)
     
@@ -38,6 +45,27 @@ export default function ProfilePage() {
       addToast('Erro ao atualizar perfil', 'error')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleToggleNegativeConfirmation = async (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked
+    setConfirmNegative(checked)
+    setPreferencesLoading(true)
+
+    try {
+      await updatePreferences({ confirmNegativeBalanceMovements: checked })
+      addToast(
+        checked
+          ? 'Confirmação para movimentações sem saldo ativada.'
+          : 'Confirmação para movimentações sem saldo desativada.',
+        'success'
+      )
+    } catch (error) {
+      addToast(getApiErrorMessage(error, 'Não foi possível atualizar a preferência.'), 'error')
+      setConfirmNegative(preferences.confirmNegativeBalanceMovements)
+    } finally {
+      setPreferencesLoading(false)
     }
   }
 
@@ -86,6 +114,52 @@ export default function ProfilePage() {
               {loading ? 'Salvando...' : 'Salvar Alterações'}
             </Button>
           </form>
+        </Card>
+      </div>
+
+      <div className="max-w-2xl mx-auto mt-8">
+        <Card
+          headerTitle="Preferências Financeiras"
+          headerSubtitle="Configure como o sistema deve lidar com movimentações que deixam a conta negativa"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-base font-semibold text-white">
+                Solicitar confirmação para movimentação sem saldo na conta
+              </h3>
+              <p className="mt-1 text-sm text-gray-300">
+                Ative para receber um aviso antes de registrar despesas que façam a conta ficar negativa quando o saldo negativo é permitido.
+              </p>
+            </div>
+
+            <label className="inline-flex cursor-pointer select-none items-center">
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={confirmNegative}
+                onChange={handleToggleNegativeConfirmation}
+                disabled={preferencesLoading}
+              />
+              <div
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition ${
+                  confirmNegative ? 'bg-accent' : 'bg-gray-600'
+                } ${preferencesLoading ? 'opacity-60' : ''}`}
+              >
+                <span
+                  className={`absolute left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                    confirmNegative ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </div>
+              <span className="ml-3 text-sm text-gray-200">
+                {confirmNegative ? 'Sim' : 'Não'}
+              </span>
+            </label>
+          </div>
+
+          {preferencesLoading && (
+            <p className="mt-3 text-sm text-gray-400">Salvando preferência...</p>
+          )}
         </Card>
       </div>
     </DashboardLayout>

--- a/frontend/utils/errors.ts
+++ b/frontend/utils/errors.ts
@@ -1,0 +1,51 @@
+import axios, { AxiosError } from 'axios';
+
+type ErrorResponse = {
+  error?: string;
+  message?: string;
+  errors?: Array<string | { message?: string; detail?: string }>;
+};
+
+export function getApiErrorMessage(error: unknown, fallbackMessage: string): string {
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError<ErrorResponse | string>;
+    const responseData = axiosError.response?.data;
+
+    if (!responseData) {
+      return fallbackMessage;
+    }
+
+    if (typeof responseData === 'string') {
+      return responseData;
+    }
+
+    if (responseData.error) {
+      return responseData.error;
+    }
+
+    if (responseData.message) {
+      return responseData.message;
+    }
+
+    if (Array.isArray(responseData.errors) && responseData.errors.length > 0) {
+      const firstError = responseData.errors[0];
+      if (typeof firstError === 'string') {
+        return firstError;
+      }
+
+      if (firstError?.message) {
+        return firstError.message;
+      }
+
+      if (firstError?.detail) {
+        return firstError.detail;
+      }
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallbackMessage;
+}


### PR DESCRIPTION
## Resumo
- habilita saldo negativo por padrão na conta principal criada com novas empresas
- expõe e persiste a preferência de confirmação de saldo negativo na API e na interface, permitindo desativar o aviso a partir do perfil
- melhora o formulário de transações para tratar erros do backend e solicitar confirmação amigável quando a conta permite saldo negativo

## Testes
- npm build (falha: comando desconhecido na versão atual do npm)
- npm run build (backend)
- npm run build (frontend, falha devido a bloqueio de rede ao baixar fontes externas)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918202f57d8833092e1d0f74bc9ef30)